### PR TITLE
feat(middleware-cookies): add initial implementation

### DIFF
--- a/.github/workflows/packages.cd.yaml
+++ b/.github/workflows/packages.cd.yaml
@@ -26,7 +26,8 @@ jobs:
       "packages/middleware-retry-status--release_created": ${{ steps.release.outputs['packages/middleware-retry-status--release_created'] }}
       "packages/middleware-base-url--tag_name": ${{ steps.release.outputs['packages/middleware-base-url--tag_name'] }}
       "packages/middleware-base-url--release_created": ${{ steps.release.outputs['packages/middleware-base-url--release_created'] }}
-      # Add more outputs for other packages here
+      "packages/middleware-cookies--tag_name": ${{ steps.release.outputs['packages/middleware-cookies--tag_name'] }}
+      "packages/middleware-cookies--release_created": ${{ steps.release.outputs['packages/middleware-cookies--release_created'] }}
 
     steps:
       - uses: googleapis/release-please-action@v4
@@ -76,3 +77,12 @@ jobs:
       package_path: "packages/middleware-base-url"
       package_name: "@qfetch/middleware-base-url"
       package_tag: ${{ needs.release-please.outputs['packages/middleware-base-url--tag_name'] }}
+
+  middleware-cookies:
+    needs: release-please
+    if: ${{ needs.release-please.outputs['packages/middleware-cookies--release_created'] == 'true' }}
+    uses: ./.github/workflows/_template.package-cd.yaml
+    with:
+      package_path: "packages/middleware-cookies"
+      package_name: "@qfetch/middleware-cookies"
+      package_tag: ${{ needs.release-please.outputs['packages/middleware-cookies--tag_name'] }}

--- a/.github/workflows/packages.ci.yaml
+++ b/.github/workflows/packages.ci.yaml
@@ -19,6 +19,7 @@ jobs:
       "packages/middleware-retry-after": ${{ steps.filter.outputs['packages/middleware-retry-after'] }}
       "packages/middleware-retry-status": ${{ steps.filter.outputs['packages/middleware-retry-status'] }}
       "packages/middleware-base-url": ${{ steps.filter.outputs['packages/middleware-base-url'] }}
+      "packages/middleware-cookies": ${{ steps.filter.outputs['packages/middleware-cookies'] }}
 
     steps:
       - name: Checkout code
@@ -42,6 +43,9 @@ jobs:
               - '.github/workflows/_template.package-ci.yaml'
             'packages/middleware-base-url':
               - 'packages/middleware-base-url/**'
+              - '.github/workflows/_template.package-ci.yaml'
+            'packages/middleware-cookies':
+              - 'packages/middleware-cookies/**'
               - '.github/workflows/_template.package-ci.yaml'
 
   core:
@@ -75,3 +79,11 @@ jobs:
     with:
       package_path: "packages/middleware-base-url"
       package_name: "@qfetch/middleware-base-url"
+
+  middleware-cookies:
+    needs: detect-changes
+    if: needs.detect-changes.outputs['packages/middleware-cookies'] == 'true'
+    uses: ./.github/workflows/_template.package-ci.yaml
+    with:
+      package_path: "packages/middleware-cookies"
+      package_name: "@qfetch/middleware-cookies"

--- a/packages/middleware-cookies/LICENSE
+++ b/packages/middleware-cookies/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 ProventusLabs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/middleware-cookies/README.md
+++ b/packages/middleware-cookies/README.md
@@ -40,7 +40,9 @@ Creates a middleware that sets multiple cookies on outgoing requests.
 **Merge behavior:**
 - If no `Cookie` header exists → sets the new cookie(s)
 - If `Cookie` header exists → appends new cookies with `; ` separator
-- Empty cookies object → passes request through unchanged
+
+**Validation:**
+- `withCookies` throws `TypeError` if passed an empty cookies object
 
 **Input handling:**
 - **String/URL inputs:** Cookies are added via `init.headers`

--- a/packages/middleware-cookies/README.md
+++ b/packages/middleware-cookies/README.md
@@ -1,0 +1,134 @@
+# @qfetch/middleware-cookies
+
+Fetch middleware for setting cookies on outgoing requests.
+
+## Overview
+
+Sets cookies on the `Cookie` header of outgoing fetch requests. Supports both single cookie (`withCookie`) and multiple cookies (`withCookies`) with automatic merging of existing cookies.
+
+**Server-side only:** In browsers, the `Cookie` header is a [forbidden header name](https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name) and cannot be set manually. This middleware is intended for server-side environments (Node.js, Deno, Bun, edge runtimes) where cookies need to be forwarded or set programmatically.
+
+Intended for use with the composable middleware system provided by [`@qfetch/core`](https://github.com/qfetch/qfetch/tree/main/packages/core#readme).
+
+## Installation
+
+```bash
+npm install @qfetch/middleware-cookies
+```
+
+## API
+
+### `withCookie(name, value)`
+
+Creates a middleware that sets a single cookie on outgoing requests.
+
+#### Parameters
+
+- `name` (`string`) **(required)** - The cookie name
+- `value` (`string`) **(required)** - The cookie value (sent as-is, encode if needed)
+
+### `withCookies(cookies)`
+
+Creates a middleware that sets multiple cookies on outgoing requests.
+
+#### Parameters
+
+- `cookies` (`Record<string, string>`) **(required)** - Object with cookie name-value pairs
+
+### Behavior
+
+**Merge behavior:**
+- If no `Cookie` header exists → sets the new cookie(s)
+- If `Cookie` header exists → appends new cookies with `; ` separator
+- Empty cookies object → passes request through unchanged
+
+**Input handling:**
+- **String/URL inputs:** Cookies are added via `init.headers`
+- **Request objects:** A new Request is created with merged headers
+
+## Usage
+
+### Single Cookie
+
+```typescript
+import { withCookie } from '@qfetch/middleware-cookies';
+
+const qfetch = withCookie('session', 'abc123')(fetch);
+
+await qfetch('https://api.example.com/data');
+// → Cookie: session=abc123
+```
+
+### Multiple Cookies
+
+```typescript
+import { withCookies } from '@qfetch/middleware-cookies';
+
+const qfetch = withCookies({
+  session: 'abc123',
+  theme: 'dark',
+  lang: 'en-US'
+})(fetch);
+
+await qfetch('https://api.example.com/data');
+// → Cookie: session=abc123; theme=dark; lang=en-US
+```
+
+### Composition with Other Middlewares
+
+```typescript
+import { withCookie, withCookies } from '@qfetch/middleware-cookies';
+import { withBaseUrl } from '@qfetch/middleware-base-url';
+import { compose } from '@qfetch/core';
+
+// Using compose with multiple cookies
+const qfetch = compose(
+  withCookies({ session: 'abc123', theme: 'dark' }),
+  withBaseUrl('https://api.example.com/v1/')
+)(fetch);
+
+await qfetch('users');
+// → https://api.example.com/v1/users with Cookie: session=abc123; theme=dark
+```
+
+### Forwarding Cookies from Incoming Requests
+
+```typescript
+import { withCookies } from '@qfetch/middleware-cookies';
+
+// In a server handler, forward cookies to an internal API
+function handleRequest(req: Request) {
+  const cookieHeader = req.headers.get('Cookie');
+  const cookies = parseCookies(cookieHeader); // your parsing function
+
+  const qfetch = withCookies(cookies)(fetch);
+  return qfetch('https://api.internal.com/data');
+}
+```
+
+### Merging with Existing Cookies
+
+```typescript
+import { withCookie } from '@qfetch/middleware-cookies';
+
+const qfetch = withCookie('session', 'abc123')(fetch);
+
+// Existing cookies are preserved
+await qfetch('https://api.example.com/data', {
+  headers: { Cookie: 'existing=value' }
+});
+// → Cookie: existing=value; session=abc123
+```
+
+## Notes
+
+- **Server-side only** - Browser fetch ignores manually set `Cookie` headers
+- Cookie values are sent as-is - encode special characters before passing to middleware
+- Works with all input types: string URLs, `URL` objects, and `Request` objects
+- For `Request` objects, creates a new Request with merged headers (immutable pattern)
+
+## Standards References
+
+- [MDN: Cookie header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cookie) - HTTP Cookie header documentation
+- [MDN: Forbidden header name](https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name) - Browser restrictions on Cookie header
+- [Fetch Standard](https://fetch.spec.whatwg.org/) - Defines Request and fetch API semantics

--- a/packages/middleware-cookies/jsr.json
+++ b/packages/middleware-cookies/jsr.json
@@ -1,0 +1,13 @@
+{
+	"name": "@qfetch/middleware-cookies",
+	"version": "0.1.0",
+	"exports": "./src/index.ts",
+	"publish": {
+		"exclude": [
+			"src/**/*test.ts",
+			"tsdown.config.ts",
+			"tsconfig.json",
+			"turbo.json"
+		]
+	}
+}

--- a/packages/middleware-cookies/package.json
+++ b/packages/middleware-cookies/package.json
@@ -1,0 +1,54 @@
+{
+	"name": "@qfetch/middleware-cookies",
+	"description": "Fetch middleware for setting cookies on outgoing requests",
+	"version": "0.1.0",
+	"author": "vabatta",
+	"bugs": "https://github.com/qfetch/qfetch/issues",
+	"devDependencies": {
+		"@qfetch/core": "workspace:",
+		"@qfetch/test-utils": "workspace:",
+		"tsdown": "catalog:",
+		"typescript": "catalog:"
+	},
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"require": "./dist/index.cjs"
+		},
+		"./package.json": "./package.json"
+	},
+	"files": [
+		"dist"
+	],
+	"homepage": "https://github.com/qfetch/qfetch/tree/main/packages/middleware-cookies#readme",
+	"keywords": [
+		"composable",
+		"fetch",
+		"http",
+		"middleware"
+	],
+	"license": "MIT",
+	"main": "./dist/index.cjs",
+	"module": "./dist/index.js",
+	"private": false,
+	"publishConfig": {
+		"access": "public"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/qfetch/qfetch.git",
+		"directory": "packages/middleware-cookies"
+	},
+	"scripts": {
+		"build": "tsdown",
+		"check-types": "tsc --noEmit",
+		"style": "biome check .",
+		"test": "node --test",
+		"test:e2e": "node --test \"src/**/*.e2e-test.ts\"",
+		"test:integration": "node --test \"src/**/*.integration-test.ts\"",
+		"test:unit": "node --test \"src/**/*.test.ts\""
+	},
+	"type": "module",
+	"types": "./dist/index.d.ts"
+}

--- a/packages/middleware-cookies/package.json
+++ b/packages/middleware-cookies/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@qfetch/middleware-cookies",
-	"description": "Fetch middleware for setting cookies on outgoing requests",
+	"description": "Fetch middleware for setting cookies on outgoing requests.",
 	"version": "0.1.0",
 	"author": "vabatta",
 	"bugs": "https://github.com/qfetch/qfetch/issues",

--- a/packages/middleware-cookies/src/index.ts
+++ b/packages/middleware-cookies/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./with-cookies.ts";

--- a/packages/middleware-cookies/src/with-cookies.integration-test.ts
+++ b/packages/middleware-cookies/src/with-cookies.integration-test.ts
@@ -349,56 +349,13 @@ suite("withCookies - Integration", { concurrency: true }, () => {
 	});
 
 	describe("handles edge cases", () => {
-		test("passes through unchanged with empty cookies object", async (ctx: TestContext) => {
-			// Arrange
-			ctx.plan(2);
-			const handler = ctx.mock.fn<RequestHandler>((req, res) => {
-				res.writeHead(200, { "Content-Type": "application/json" });
-				res.end(JSON.stringify({ cookie: req.headers.cookie ?? null }));
-			});
-
-			const { baseUrl } = await createTestServer(ctx, handler);
-			const qfetch = withCookies({})(fetch);
-
-			// Act
-			const response = await qfetch(`${baseUrl}/api/data`, {
-				signal: ctx.signal,
-			});
-			const data = (await response.json()) as { cookie: string | null };
-
-			// Assert
-			ctx.assert.strictEqual(response.status, 200, "returns successful status");
-			ctx.assert.strictEqual(
-				data.cookie,
-				null,
-				"no cookie header sent with empty object",
-			);
-		});
-
-		test("preserves existing cookies with empty middleware object", async (ctx: TestContext) => {
-			// Arrange
-			ctx.plan(2);
-			const handler = ctx.mock.fn<RequestHandler>((req, res) => {
-				res.writeHead(200, { "Content-Type": "application/json" });
-				res.end(JSON.stringify({ cookie: req.headers.cookie }));
-			});
-
-			const { baseUrl } = await createTestServer(ctx, handler);
-			const qfetch = withCookies({})(fetch);
-
-			// Act
-			const response = await qfetch(`${baseUrl}/api/data`, {
-				headers: { Cookie: "existing=value" },
-				signal: ctx.signal,
-			});
-			const data = (await response.json()) as { cookie: string };
-
-			// Assert
-			ctx.assert.strictEqual(response.status, 200, "returns successful status");
-			ctx.assert.strictEqual(
-				data.cookie,
-				"existing=value",
-				"existing cookie is preserved",
+		test("throws when passed empty cookies object", (ctx: TestContext) => {
+			// Arrange & Act & Assert
+			ctx.plan(1);
+			ctx.assert.throws(
+				() => withCookies({}),
+				TypeError,
+				"throws TypeError for empty cookies object",
 			);
 		});
 

--- a/packages/middleware-cookies/src/with-cookies.integration-test.ts
+++ b/packages/middleware-cookies/src/with-cookies.integration-test.ts
@@ -1,0 +1,434 @@
+import { describe, suite, type TestContext, test } from "node:test";
+
+import { createTestServer, type RequestHandler } from "@qfetch/test-utils";
+
+import { withCookie, withCookies } from "./with-cookies.ts";
+
+/* node:coverage disable */
+
+suite("withCookie - Integration", { concurrency: true }, () => {
+	describe("sends cookie header to server", () => {
+		test("sends single cookie with string URL", async (ctx: TestContext) => {
+			// Arrange
+			ctx.plan(2);
+			const handler = ctx.mock.fn<RequestHandler>((req, res) => {
+				res.writeHead(200, { "Content-Type": "application/json" });
+				res.end(JSON.stringify({ cookie: req.headers.cookie }));
+			});
+
+			const { baseUrl } = await createTestServer(ctx, handler);
+			const qfetch = withCookie("session", "abc123")(fetch);
+
+			// Act
+			const response = await qfetch(`${baseUrl}/api/data`, {
+				signal: ctx.signal,
+			});
+			const data = (await response.json()) as { cookie: string };
+
+			// Assert
+			ctx.assert.strictEqual(response.status, 200, "returns successful status");
+			ctx.assert.strictEqual(
+				data.cookie,
+				"session=abc123",
+				"server receives cookie header",
+			);
+		});
+
+		test("sends single cookie with URL object", async (ctx: TestContext) => {
+			// Arrange
+			ctx.plan(2);
+			const handler = ctx.mock.fn<RequestHandler>((req, res) => {
+				res.writeHead(200, { "Content-Type": "application/json" });
+				res.end(JSON.stringify({ cookie: req.headers.cookie }));
+			});
+
+			const { baseUrl } = await createTestServer(ctx, handler);
+			const qfetch = withCookie("token", "xyz789")(fetch);
+
+			// Act
+			const response = await qfetch(new URL(`${baseUrl}/api/data`), {
+				signal: ctx.signal,
+			});
+			const data = (await response.json()) as { cookie: string };
+
+			// Assert
+			ctx.assert.strictEqual(response.status, 200, "returns successful status");
+			ctx.assert.strictEqual(
+				data.cookie,
+				"token=xyz789",
+				"server receives cookie header",
+			);
+		});
+
+		test("sends single cookie with Request object", async (ctx: TestContext) => {
+			// Arrange
+			ctx.plan(2);
+			const handler = ctx.mock.fn<RequestHandler>((req, res) => {
+				res.writeHead(200, { "Content-Type": "application/json" });
+				res.end(JSON.stringify({ cookie: req.headers.cookie }));
+			});
+
+			const { baseUrl } = await createTestServer(ctx, handler);
+			const qfetch = withCookie("auth", "secret")(fetch);
+
+			// Act
+			const request = new Request(`${baseUrl}/api/data`, {
+				signal: ctx.signal,
+			});
+			const response = await qfetch(request);
+			const data = (await response.json()) as { cookie: string };
+
+			// Assert
+			ctx.assert.strictEqual(response.status, 200, "returns successful status");
+			ctx.assert.strictEqual(
+				data.cookie,
+				"auth=secret",
+				"server receives cookie header",
+			);
+		});
+	});
+
+	describe("merges with existing cookies", () => {
+		test("appends to existing cookie header from init", async (ctx: TestContext) => {
+			// Arrange
+			ctx.plan(2);
+			const handler = ctx.mock.fn<RequestHandler>((req, res) => {
+				res.writeHead(200, { "Content-Type": "application/json" });
+				res.end(JSON.stringify({ cookie: req.headers.cookie }));
+			});
+
+			const { baseUrl } = await createTestServer(ctx, handler);
+			const qfetch = withCookie("session", "abc123")(fetch);
+
+			// Act
+			const response = await qfetch(`${baseUrl}/api/data`, {
+				headers: { Cookie: "existing=value" },
+				signal: ctx.signal,
+			});
+			const data = (await response.json()) as { cookie: string };
+
+			// Assert
+			ctx.assert.strictEqual(response.status, 200, "returns successful status");
+			ctx.assert.strictEqual(
+				data.cookie,
+				"existing=value; session=abc123",
+				"server receives merged cookies",
+			);
+		});
+
+		test("appends to existing cookie header from Request object", async (ctx: TestContext) => {
+			// Arrange
+			ctx.plan(2);
+			const handler = ctx.mock.fn<RequestHandler>((req, res) => {
+				res.writeHead(200, { "Content-Type": "application/json" });
+				res.end(JSON.stringify({ cookie: req.headers.cookie }));
+			});
+
+			const { baseUrl } = await createTestServer(ctx, handler);
+			const qfetch = withCookie("session", "abc123")(fetch);
+
+			// Act
+			const request = new Request(`${baseUrl}/api/data`, {
+				headers: { Cookie: "existing=value" },
+				signal: ctx.signal,
+			});
+			const response = await qfetch(request);
+			const data = (await response.json()) as { cookie: string };
+
+			// Assert
+			ctx.assert.strictEqual(response.status, 200, "returns successful status");
+			ctx.assert.strictEqual(
+				data.cookie,
+				"existing=value; session=abc123",
+				"server receives merged cookies",
+			);
+		});
+	});
+
+	describe("HTTP methods", () => {
+		test("sends cookie with POST request", async (ctx: TestContext) => {
+			// Arrange
+			ctx.plan(3);
+			const handler = ctx.mock.fn<RequestHandler>((req, res) => {
+				res.writeHead(200, { "Content-Type": "application/json" });
+				res.end(
+					JSON.stringify({ method: req.method, cookie: req.headers.cookie }),
+				);
+			});
+
+			const { baseUrl } = await createTestServer(ctx, handler);
+			const qfetch = withCookie("csrf", "token123")(fetch);
+
+			// Act
+			const response = await qfetch(`${baseUrl}/api/data`, {
+				method: "POST",
+				signal: ctx.signal,
+			});
+			const data = (await response.json()) as {
+				method: string;
+				cookie: string;
+			};
+
+			// Assert
+			ctx.assert.strictEqual(response.status, 200, "returns successful status");
+			ctx.assert.strictEqual(data.method, "POST", "uses POST method");
+			ctx.assert.strictEqual(
+				data.cookie,
+				"csrf=token123",
+				"server receives cookie header",
+			);
+		});
+
+		test("sends cookie with PUT request and body", async (ctx: TestContext) => {
+			// Arrange
+			ctx.plan(3);
+			const handler = ctx.mock.fn<RequestHandler>((req, res) => {
+				let body = "";
+				req.on("data", (chunk) => {
+					body += chunk.toString();
+				});
+				req.on("end", () => {
+					res.writeHead(200, { "Content-Type": "application/json" });
+					res.end(
+						JSON.stringify({
+							method: req.method,
+							cookie: req.headers.cookie,
+							body: JSON.parse(body),
+						}),
+					);
+				});
+			});
+
+			const { baseUrl } = await createTestServer(ctx, handler);
+			const qfetch = withCookie("session", "abc123")(fetch);
+
+			// Act
+			const response = await qfetch(`${baseUrl}/api/users/1`, {
+				method: "PUT",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ name: "Updated" }),
+				signal: ctx.signal,
+			});
+			const data = (await response.json()) as {
+				method: string;
+				cookie: string;
+				body: { name: string };
+			};
+
+			// Assert
+			ctx.assert.strictEqual(response.status, 200, "returns successful status");
+			ctx.assert.strictEqual(
+				data.cookie,
+				"session=abc123",
+				"server receives cookie header",
+			);
+			ctx.assert.deepStrictEqual(
+				data.body,
+				{ name: "Updated" },
+				"body is preserved",
+			);
+		});
+	});
+
+	describe("signal handling", () => {
+		test("propagates abort signal to underlying fetch", async (ctx: TestContext) => {
+			// Arrange
+			ctx.plan(1);
+			const handler = ctx.mock.fn<RequestHandler>((_req, res) => {
+				res.writeHead(200, { "Content-Type": "application/json" });
+				res.end(JSON.stringify({ success: true }));
+			});
+
+			const { baseUrl } = await createTestServer(ctx, handler);
+			const qfetch = withCookie("session", "abc123")(fetch);
+			const controller = new AbortController();
+
+			// Act
+			const promise = qfetch(`${baseUrl}/api/data`, {
+				signal: controller.signal,
+			});
+			controller.abort();
+
+			// Assert
+			await ctx.assert.rejects(
+				() => promise,
+				(e: unknown) => e instanceof DOMException && e.name === "AbortError",
+				"propagates abort to underlying fetch",
+			);
+		});
+	});
+});
+
+suite("withCookies - Integration", { concurrency: true }, () => {
+	describe("sends multiple cookies to server", () => {
+		test("sends multiple cookies with string URL", async (ctx: TestContext) => {
+			// Arrange
+			ctx.plan(2);
+			const handler = ctx.mock.fn<RequestHandler>((req, res) => {
+				res.writeHead(200, { "Content-Type": "application/json" });
+				res.end(JSON.stringify({ cookie: req.headers.cookie }));
+			});
+
+			const { baseUrl } = await createTestServer(ctx, handler);
+			const qfetch = withCookies({
+				session: "abc123",
+				theme: "dark",
+				lang: "en-US",
+			})(fetch);
+
+			// Act
+			const response = await qfetch(`${baseUrl}/api/data`, {
+				signal: ctx.signal,
+			});
+			const data = (await response.json()) as { cookie: string };
+
+			// Assert
+			ctx.assert.strictEqual(response.status, 200, "returns successful status");
+			ctx.assert.strictEqual(
+				data.cookie,
+				"session=abc123; theme=dark; lang=en-US",
+				"server receives all cookies",
+			);
+		});
+
+		test("sends multiple cookies with Request object", async (ctx: TestContext) => {
+			// Arrange
+			ctx.plan(2);
+			const handler = ctx.mock.fn<RequestHandler>((req, res) => {
+				res.writeHead(200, { "Content-Type": "application/json" });
+				res.end(JSON.stringify({ cookie: req.headers.cookie }));
+			});
+
+			const { baseUrl } = await createTestServer(ctx, handler);
+			const qfetch = withCookies({ session: "abc123", theme: "dark" })(fetch);
+
+			// Act
+			const request = new Request(`${baseUrl}/api/data`, {
+				signal: ctx.signal,
+			});
+			const response = await qfetch(request);
+			const data = (await response.json()) as { cookie: string };
+
+			// Assert
+			ctx.assert.strictEqual(response.status, 200, "returns successful status");
+			ctx.assert.strictEqual(
+				data.cookie,
+				"session=abc123; theme=dark",
+				"server receives all cookies",
+			);
+		});
+	});
+
+	describe("merges with existing cookies", () => {
+		test("appends multiple cookies to existing header", async (ctx: TestContext) => {
+			// Arrange
+			ctx.plan(2);
+			const handler = ctx.mock.fn<RequestHandler>((req, res) => {
+				res.writeHead(200, { "Content-Type": "application/json" });
+				res.end(JSON.stringify({ cookie: req.headers.cookie }));
+			});
+
+			const { baseUrl } = await createTestServer(ctx, handler);
+			const qfetch = withCookies({ session: "abc123", theme: "dark" })(fetch);
+
+			// Act
+			const response = await qfetch(`${baseUrl}/api/data`, {
+				headers: { Cookie: "existing=value" },
+				signal: ctx.signal,
+			});
+			const data = (await response.json()) as { cookie: string };
+
+			// Assert
+			ctx.assert.strictEqual(response.status, 200, "returns successful status");
+			ctx.assert.strictEqual(
+				data.cookie,
+				"existing=value; session=abc123; theme=dark",
+				"server receives merged cookies",
+			);
+		});
+	});
+
+	describe("handles edge cases", () => {
+		test("passes through unchanged with empty cookies object", async (ctx: TestContext) => {
+			// Arrange
+			ctx.plan(2);
+			const handler = ctx.mock.fn<RequestHandler>((req, res) => {
+				res.writeHead(200, { "Content-Type": "application/json" });
+				res.end(JSON.stringify({ cookie: req.headers.cookie ?? null }));
+			});
+
+			const { baseUrl } = await createTestServer(ctx, handler);
+			const qfetch = withCookies({})(fetch);
+
+			// Act
+			const response = await qfetch(`${baseUrl}/api/data`, {
+				signal: ctx.signal,
+			});
+			const data = (await response.json()) as { cookie: string | null };
+
+			// Assert
+			ctx.assert.strictEqual(response.status, 200, "returns successful status");
+			ctx.assert.strictEqual(
+				data.cookie,
+				null,
+				"no cookie header sent with empty object",
+			);
+		});
+
+		test("preserves existing cookies with empty middleware object", async (ctx: TestContext) => {
+			// Arrange
+			ctx.plan(2);
+			const handler = ctx.mock.fn<RequestHandler>((req, res) => {
+				res.writeHead(200, { "Content-Type": "application/json" });
+				res.end(JSON.stringify({ cookie: req.headers.cookie }));
+			});
+
+			const { baseUrl } = await createTestServer(ctx, handler);
+			const qfetch = withCookies({})(fetch);
+
+			// Act
+			const response = await qfetch(`${baseUrl}/api/data`, {
+				headers: { Cookie: "existing=value" },
+				signal: ctx.signal,
+			});
+			const data = (await response.json()) as { cookie: string };
+
+			// Assert
+			ctx.assert.strictEqual(response.status, 200, "returns successful status");
+			ctx.assert.strictEqual(
+				data.cookie,
+				"existing=value",
+				"existing cookie is preserved",
+			);
+		});
+
+		test("handles cookies with special characters", async (ctx: TestContext) => {
+			// Arrange
+			ctx.plan(2);
+			const handler = ctx.mock.fn<RequestHandler>((req, res) => {
+				res.writeHead(200, { "Content-Type": "application/json" });
+				res.end(JSON.stringify({ cookie: req.headers.cookie }));
+			});
+
+			const { baseUrl } = await createTestServer(ctx, handler);
+			const qfetch = withCookies({
+				data: "hello%20world",
+				path: "/api/v1",
+			})(fetch);
+
+			// Act
+			const response = await qfetch(`${baseUrl}/api/data`, {
+				signal: ctx.signal,
+			});
+			const data = (await response.json()) as { cookie: string };
+
+			// Assert
+			ctx.assert.strictEqual(response.status, 200, "returns successful status");
+			ctx.assert.strictEqual(
+				data.cookie,
+				"data=hello%20world; path=/api/v1",
+				"cookies with special characters are sent correctly",
+			);
+		});
+	});
+});

--- a/packages/middleware-cookies/src/with-cookies.test.ts
+++ b/packages/middleware-cookies/src/with-cookies.test.ts
@@ -1,0 +1,306 @@
+import { describe, suite, type TestContext, test } from "node:test";
+
+import { withCookie, withCookies } from "./with-cookies.ts";
+
+/* node:coverage disable */
+
+suite("withCookie - Unit", () => {
+	describe("sets Cookie header on outgoing requests", () => {
+		test("sets cookie header with string URL input", async (ctx: TestContext) => {
+			// Arrange
+			ctx.plan(1);
+			const fetchMock = ctx.mock.fn(fetch, async (_input, init) => {
+				const headers = new Headers(init?.headers);
+				ctx.assert.equal(
+					headers.get("Cookie"),
+					"session=abc123",
+					"cookie header is set correctly",
+				);
+				return new Response();
+			});
+
+			const qfetch = withCookie("session", "abc123")(fetchMock);
+
+			// Act
+			await qfetch("https://example.com");
+		});
+
+		test("sets cookie header with URL object input", async (ctx: TestContext) => {
+			// Arrange
+			ctx.plan(1);
+			const fetchMock = ctx.mock.fn(fetch, async (_input, init) => {
+				const headers = new Headers(init?.headers);
+				ctx.assert.equal(
+					headers.get("Cookie"),
+					"token=xyz789",
+					"cookie header is set correctly",
+				);
+				return new Response();
+			});
+
+			const qfetch = withCookie("token", "xyz789")(fetchMock);
+
+			// Act
+			await qfetch(new URL("https://example.com"));
+		});
+
+		test("sets cookie header with Request object input", async (ctx: TestContext) => {
+			// Arrange
+			ctx.plan(2);
+			const fetchMock = ctx.mock.fn(fetch, async (input) => {
+				ctx.assert.ok(input instanceof Request, "input is a Request");
+				ctx.assert.equal(
+					(input as Request).headers.get("Cookie"),
+					"auth=secret",
+					"cookie header is set on Request",
+				);
+				return new Response();
+			});
+
+			const qfetch = withCookie("auth", "secret")(fetchMock);
+
+			// Act
+			await qfetch(new Request("https://example.com"));
+		});
+	});
+
+	describe("merges with existing Cookie headers", () => {
+		test("appends to existing cookie header from init", async (ctx: TestContext) => {
+			// Arrange
+			ctx.plan(1);
+			const fetchMock = ctx.mock.fn(fetch, async (_input, init) => {
+				const headers = new Headers(init?.headers);
+				ctx.assert.equal(
+					headers.get("Cookie"),
+					"existing=value; session=abc123",
+					"cookie is appended to existing header",
+				);
+				return new Response();
+			});
+
+			const qfetch = withCookie("session", "abc123")(fetchMock);
+
+			// Act
+			await qfetch("https://example.com", {
+				headers: { Cookie: "existing=value" },
+			});
+		});
+
+		test("appends to existing cookie header from Request object", async (ctx: TestContext) => {
+			// Arrange
+			ctx.plan(1);
+			const fetchMock = ctx.mock.fn(fetch, async (input) => {
+				ctx.assert.equal(
+					(input as Request).headers.get("Cookie"),
+					"existing=value; session=abc123",
+					"cookie is appended to existing Request header",
+				);
+				return new Response();
+			});
+
+			const qfetch = withCookie("session", "abc123")(fetchMock);
+
+			// Act
+			await qfetch(
+				new Request("https://example.com", {
+					headers: { Cookie: "existing=value" },
+				}),
+			);
+		});
+	});
+
+	describe("handles edge cases", () => {
+		test("handles cookie values with special characters", async (ctx: TestContext) => {
+			// Arrange
+			ctx.plan(1);
+			const fetchMock = ctx.mock.fn(fetch, async (_input, init) => {
+				const headers = new Headers(init?.headers);
+				ctx.assert.equal(
+					headers.get("Cookie"),
+					"data=hello%20world",
+					"cookie with special characters is set correctly",
+				);
+				return new Response();
+			});
+
+			const qfetch = withCookie("data", "hello%20world")(fetchMock);
+
+			// Act
+			await qfetch("https://example.com");
+		});
+
+		test("handles empty cookie value", async (ctx: TestContext) => {
+			// Arrange
+			ctx.plan(1);
+			const fetchMock = ctx.mock.fn(fetch, async (_input, init) => {
+				const headers = new Headers(init?.headers);
+				ctx.assert.equal(
+					headers.get("Cookie"),
+					"empty=",
+					"empty cookie value is set correctly",
+				);
+				return new Response();
+			});
+
+			const qfetch = withCookie("empty", "")(fetchMock);
+
+			// Act
+			await qfetch("https://example.com");
+		});
+	});
+});
+
+suite("withCookies - Unit", () => {
+	describe("sets multiple cookies on outgoing requests", () => {
+		test("sets multiple cookies from object", async (ctx: TestContext) => {
+			// Arrange
+			ctx.plan(1);
+			const fetchMock = ctx.mock.fn(fetch, async (_input, init) => {
+				const headers = new Headers(init?.headers);
+				ctx.assert.equal(
+					headers.get("Cookie"),
+					"session=abc123; theme=dark",
+					"multiple cookies are set correctly",
+				);
+				return new Response();
+			});
+
+			const qfetch = withCookies({ session: "abc123", theme: "dark" })(
+				fetchMock,
+			);
+
+			// Act
+			await qfetch("https://example.com");
+		});
+
+		test("sets single cookie from object", async (ctx: TestContext) => {
+			// Arrange
+			ctx.plan(1);
+			const fetchMock = ctx.mock.fn(fetch, async (_input, init) => {
+				const headers = new Headers(init?.headers);
+				ctx.assert.equal(
+					headers.get("Cookie"),
+					"session=abc123",
+					"single cookie from object is set correctly",
+				);
+				return new Response();
+			});
+
+			const qfetch = withCookies({ session: "abc123" })(fetchMock);
+
+			// Act
+			await qfetch("https://example.com");
+		});
+
+		test("sets cookies with Request object input", async (ctx: TestContext) => {
+			// Arrange
+			ctx.plan(1);
+			const fetchMock = ctx.mock.fn(fetch, async (input) => {
+				ctx.assert.equal(
+					(input as Request).headers.get("Cookie"),
+					"session=abc123; theme=dark",
+					"cookies are set on Request",
+				);
+				return new Response();
+			});
+
+			const qfetch = withCookies({ session: "abc123", theme: "dark" })(
+				fetchMock,
+			);
+
+			// Act
+			await qfetch(new Request("https://example.com"));
+		});
+	});
+
+	describe("merges with existing Cookie headers", () => {
+		test("appends to existing cookie header from init", async (ctx: TestContext) => {
+			// Arrange
+			ctx.plan(1);
+			const fetchMock = ctx.mock.fn(fetch, async (_input, init) => {
+				const headers = new Headers(init?.headers);
+				ctx.assert.equal(
+					headers.get("Cookie"),
+					"existing=value; session=abc123; theme=dark",
+					"cookies are appended to existing header",
+				);
+				return new Response();
+			});
+
+			const qfetch = withCookies({ session: "abc123", theme: "dark" })(
+				fetchMock,
+			);
+
+			// Act
+			await qfetch("https://example.com", {
+				headers: { Cookie: "existing=value" },
+			});
+		});
+
+		test("appends to existing cookie header from Request object", async (ctx: TestContext) => {
+			// Arrange
+			ctx.plan(1);
+			const fetchMock = ctx.mock.fn(fetch, async (input) => {
+				ctx.assert.equal(
+					(input as Request).headers.get("Cookie"),
+					"existing=value; session=abc123; theme=dark",
+					"cookies are appended to existing Request header",
+				);
+				return new Response();
+			});
+
+			const qfetch = withCookies({ session: "abc123", theme: "dark" })(
+				fetchMock,
+			);
+
+			// Act
+			await qfetch(
+				new Request("https://example.com", {
+					headers: { Cookie: "existing=value" },
+				}),
+			);
+		});
+	});
+
+	describe("handles edge cases", () => {
+		test("handles empty cookies object", async (ctx: TestContext) => {
+			// Arrange
+			ctx.plan(1);
+			const fetchMock = ctx.mock.fn(fetch, async (_input, init) => {
+				const headers = new Headers(init?.headers);
+				ctx.assert.equal(
+					headers.get("Cookie"),
+					null,
+					"no cookie header is set for empty object",
+				);
+				return new Response();
+			});
+
+			const qfetch = withCookies({})(fetchMock);
+
+			// Act
+			await qfetch("https://example.com");
+		});
+
+		test("preserves existing cookies when adding empty object", async (ctx: TestContext) => {
+			// Arrange
+			ctx.plan(1);
+			const fetchMock = ctx.mock.fn(fetch, async (_input, init) => {
+				const headers = new Headers(init?.headers);
+				ctx.assert.equal(
+					headers.get("Cookie"),
+					"existing=value",
+					"existing cookie is preserved",
+				);
+				return new Response();
+			});
+
+			const qfetch = withCookies({})(fetchMock);
+
+			// Act
+			await qfetch("https://example.com", {
+				headers: { Cookie: "existing=value" },
+			});
+		});
+	});
+});

--- a/packages/middleware-cookies/src/with-cookies.test.ts
+++ b/packages/middleware-cookies/src/with-cookies.test.ts
@@ -263,44 +263,14 @@ suite("withCookies - Unit", () => {
 	});
 
 	describe("handles edge cases", () => {
-		test("handles empty cookies object", async (ctx: TestContext) => {
-			// Arrange
+		test("throws when passed empty cookies object", (ctx: TestContext) => {
+			// Arrange & Act & Assert
 			ctx.plan(1);
-			const fetchMock = ctx.mock.fn(fetch, async (_input, init) => {
-				const headers = new Headers(init?.headers);
-				ctx.assert.equal(
-					headers.get("Cookie"),
-					null,
-					"no cookie header is set for empty object",
-				);
-				return new Response();
-			});
-
-			const qfetch = withCookies({})(fetchMock);
-
-			// Act
-			await qfetch("https://example.com");
-		});
-
-		test("preserves existing cookies when adding empty object", async (ctx: TestContext) => {
-			// Arrange
-			ctx.plan(1);
-			const fetchMock = ctx.mock.fn(fetch, async (_input, init) => {
-				const headers = new Headers(init?.headers);
-				ctx.assert.equal(
-					headers.get("Cookie"),
-					"existing=value",
-					"existing cookie is preserved",
-				);
-				return new Response();
-			});
-
-			const qfetch = withCookies({})(fetchMock);
-
-			// Act
-			await qfetch("https://example.com", {
-				headers: { Cookie: "existing=value" },
-			});
+			ctx.assert.throws(
+				() => withCookies({}),
+				TypeError,
+				"throws TypeError for empty cookies object",
+			);
 		});
 	});
 });

--- a/packages/middleware-cookies/src/with-cookies.test.ts
+++ b/packages/middleware-cookies/src/with-cookies.test.ts
@@ -262,15 +262,30 @@ suite("withCookies - Unit", () => {
 		});
 	});
 
-	describe("handles edge cases", () => {
-		test("throws when passed empty cookies object", (ctx: TestContext) => {
-			// Arrange & Act & Assert
-			ctx.plan(1);
-			ctx.assert.throws(
-				() => withCookies({}),
-				TypeError,
-				"throws TypeError for empty cookies object",
-			);
+	describe("initialisation constraints", () => {
+		test("throws an error for invalid cookies input", async (ctx: TestContext) => {
+			const invalidInputs = [
+				{ input: {}, description: "empty object" },
+				{ input: null, description: "null" },
+				{ input: undefined, description: "undefined" },
+				{ input: [], description: "array" },
+				{ input: new Map(), description: "Map instance" },
+				{ input: new (class Cookies {})(), description: "class instance" },
+			];
+
+			ctx.plan(invalidInputs.length);
+
+			for (const { input, description } of invalidInputs) {
+				await ctx.test(description, (subCtx) => {
+					subCtx.plan(1);
+					subCtx.assert.throws(
+						// @ts-expect-error -- testing invalid input types
+						() => withCookies(input),
+						TypeError,
+						`throws TypeError for ${description}`,
+					);
+				});
+			}
 		});
 	});
 });

--- a/packages/middleware-cookies/src/with-cookies.ts
+++ b/packages/middleware-cookies/src/with-cookies.ts
@@ -1,4 +1,4 @@
-import type { FetchExecutor } from "@qfetch/core";
+import type { Middleware } from "@qfetch/core";
 
 /**
  * Cookie entries as name-value pairs.
@@ -113,7 +113,10 @@ const getExistingHeaders = (
  * @see {@link withCookies} for setting multiple cookies at once
  * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cookie MDN: Cookie header}
  */
-export const withCookie = (name: string, value: string): FetchExecutor => {
+export const withCookie: Middleware<[name: string, value: string]> = (
+	name,
+	value,
+) => {
 	const cookieString = `${name}=${value}`;
 
 	return (next) => async (input, init) => {
@@ -199,9 +202,15 @@ export const withCookie = (name: string, value: string): FetchExecutor => {
  * @see {@link withCookie} for setting a single cookie
  * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cookie MDN: Cookie header}
  */
-export const withCookies = (cookies: CookieEntries): FetchExecutor => {
-	if (!cookies || Object.keys(cookies).length === 0) {
-		throw new TypeError("withCookies requires at least one cookie");
+export const withCookies: Middleware<[cookies: CookieEntries]> = (cookies) => {
+	if (
+		!cookies ||
+		cookies.constructor !== Object ||
+		Object.keys(cookies).length === 0
+	) {
+		throw new TypeError(
+			"withCookies requires an object with at least one cookie",
+		);
 	}
 
 	const cookieString = serializeCookies(cookies);

--- a/packages/middleware-cookies/src/with-cookies.ts
+++ b/packages/middleware-cookies/src/with-cookies.ts
@@ -1,0 +1,234 @@
+import type { FetchExecutor } from "@qfetch/core";
+
+/**
+ * Cookie entries as name-value pairs.
+ *
+ * Each key is a cookie name and each value is the cookie value.
+ * Values are sent as-is without encoding - ensure values are properly
+ * encoded if they contain special characters.
+ *
+ * @example
+ * ```ts
+ * const cookies: CookieEntries = {
+ *   session: "abc123",
+ *   theme: "dark",
+ *   lang: "en-US"
+ * };
+ * ```
+ */
+export type CookieEntries = Record<string, string>;
+
+/**
+ * Serializes cookies object to Cookie header format.
+ *
+ * @param cookies - Object with cookie name-value pairs
+ * @returns Cookie header string in `name=value; name=value` format
+ */
+const serializeCookies = (cookies: CookieEntries): string => {
+	return Object.entries(cookies)
+		.map(([name, value]) => `${name}=${value}`)
+		.join("; ");
+};
+
+/**
+ * Merges new cookies with existing Cookie header value.
+ *
+ * @param existing - Existing Cookie header value or null
+ * @param newCookies - New cookies to append
+ * @returns Merged cookie string
+ */
+const mergeCookies = (existing: string | null, newCookies: string): string => {
+	if (!newCookies) return existing ?? "";
+	if (!existing) return newCookies;
+	return `${existing}; ${newCookies}`;
+};
+
+/**
+ * Gets existing Cookie header from input and init.
+ *
+ * @param input - Request input (string, URL, or Request)
+ * @param init - Optional RequestInit with headers
+ * @returns Existing Cookie header value or null
+ */
+const getExistingCookie = (
+	input: RequestInfo | URL,
+	init?: RequestInit,
+): string | null => {
+	if (input instanceof Request) {
+		return input.headers.get("Cookie");
+	}
+	if (init?.headers) {
+		const headers = new Headers(init.headers);
+		return headers.get("Cookie");
+	}
+	return null;
+};
+
+/**
+ * Middleware that sets a single cookie on outgoing fetch requests.
+ *
+ * Adds a cookie to the `Cookie` header of outgoing requests. If the request
+ * already has a `Cookie` header, the new cookie is appended to the existing
+ * cookies.
+ *
+ * @remarks
+ * **Server-side only:** In browsers, the `Cookie` header is a
+ * {@link https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name forbidden header name}
+ * and cannot be set manually. This middleware is intended for server-side
+ * environments (Node.js, Deno, Bun, edge runtimes) where cookies need to be
+ * forwarded or set programmatically.
+ *
+ * **Merge behavior:**
+ * - If no `Cookie` header exists → sets `name=value`
+ * - If `Cookie` header exists → appends `; name=value`
+ *
+ * **Input handling:**
+ * - **String/URL inputs:** Cookie is added via `init.headers`
+ * - **Request objects:** A new Request is created with merged headers
+ *
+ * @param name - The cookie name
+ * @param value - The cookie value (sent as-is, encode if needed)
+ * @returns A fetch executor that adds the cookie to requests
+ *
+ * @example
+ * ```ts
+ * import { withCookie } from "@qfetch/middleware-cookies";
+ *
+ * // Basic usage
+ * const qfetch = withCookie("session", "abc123")(fetch);
+ * await qfetch("https://api.example.com/data");
+ * // → Cookie: session=abc123
+ * ```
+ *
+ * @example
+ * ```ts
+ * import { withCookie } from "@qfetch/middleware-cookies";
+ * import { compose } from "@qfetch/core";
+ *
+ * // Composition with multiple cookies
+ * const qfetch = compose(
+ *   withCookie("session", "abc123"),
+ *   withCookie("theme", "dark")
+ * )(fetch);
+ * await qfetch("https://api.example.com/data");
+ * // → Cookie: session=abc123; theme=dark
+ * ```
+ *
+ * @see {@link withCookies} for setting multiple cookies at once
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cookie MDN: Cookie header}
+ */
+export const withCookie = (name: string, value: string): FetchExecutor => {
+	const cookieString = `${name}=${value}`;
+
+	return (next) => async (input, init) => {
+		const existingCookie = getExistingCookie(input, init);
+		const mergedCookie = mergeCookies(existingCookie, cookieString);
+
+		if (input instanceof Request) {
+			const headers = new Headers(input.headers);
+			headers.set("Cookie", mergedCookie);
+			input = new Request(input, { headers });
+			return next(input);
+		}
+
+		const headers = new Headers(init?.headers);
+		headers.set("Cookie", mergedCookie);
+		return next(input, { ...init, headers });
+	};
+};
+
+/**
+ * Middleware that sets multiple cookies on outgoing fetch requests.
+ *
+ * Adds multiple cookies to the `Cookie` header of outgoing requests. If the
+ * request already has a `Cookie` header, new cookies are appended to the
+ * existing cookies.
+ *
+ * @remarks
+ * **Server-side only:** In browsers, the `Cookie` header is a
+ * {@link https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name forbidden header name}
+ * and cannot be set manually. This middleware is intended for server-side
+ * environments (Node.js, Deno, Bun, edge runtimes) where cookies need to be
+ * forwarded or set programmatically.
+ *
+ * **Merge behavior:**
+ * - If no `Cookie` header exists → sets `name1=value1; name2=value2`
+ * - If `Cookie` header exists → appends `; name1=value1; name2=value2`
+ * - Empty cookies object → passes request through unchanged
+ *
+ * **Input handling:**
+ * - **String/URL inputs:** Cookies are added via `init.headers`
+ * - **Request objects:** A new Request is created with merged headers
+ *
+ * @param cookies - Object with cookie name-value pairs. See {@link CookieEntries}.
+ * @returns A fetch executor that adds the cookies to requests
+ *
+ * @example
+ * ```ts
+ * import { withCookies } from "@qfetch/middleware-cookies";
+ *
+ * // Basic usage with multiple cookies
+ * const qfetch = withCookies({
+ *   session: "abc123",
+ *   theme: "dark",
+ *   lang: "en-US"
+ * })(fetch);
+ *
+ * await qfetch("https://api.example.com/data");
+ * // → Cookie: session=abc123; theme=dark; lang=en-US
+ * ```
+ *
+ * @example
+ * ```ts
+ * import { withCookies } from "@qfetch/middleware-cookies";
+ * import { compose } from "@qfetch/core";
+ *
+ * // Composition with other middlewares
+ * const qfetch = compose(
+ *   withCookies({ session: "abc123" }),
+ *   withBaseUrl("https://api.example.com")
+ * )(fetch);
+ *
+ * await qfetch("/data");
+ * // → https://api.example.com/data with Cookie: session=abc123
+ * ```
+ *
+ * @example
+ * ```ts
+ * import { withCookies } from "@qfetch/middleware-cookies";
+ *
+ * // Forwarding cookies from an incoming request (e.g., in a server handler)
+ * function handleRequest(req: Request) {
+ *   const cookies = parseCookies(req.headers.get("Cookie"));
+ *   const qfetch = withCookies(cookies)(fetch);
+ *   return qfetch("https://api.internal.com/data");
+ * }
+ * ```
+ *
+ * @see {@link withCookie} for setting a single cookie
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cookie MDN: Cookie header}
+ */
+export const withCookies = (cookies: CookieEntries): FetchExecutor => {
+	const cookieString = serializeCookies(cookies);
+
+	return (next) => async (input, init) => {
+		if (!cookieString) {
+			// No cookies to add, pass through unchanged
+			return next(input, init);
+		}
+
+		const existingCookie = getExistingCookie(input, init);
+		const mergedCookie = mergeCookies(existingCookie, cookieString);
+
+		if (input instanceof Request) {
+			const headers = new Headers(input.headers);
+			headers.set("Cookie", mergedCookie);
+			input = new Request(input, { headers });
+			return next(input);
+		}
+
+		const headers = new Headers(init?.headers);
+		headers.set("Cookie", mergedCookie);
+		return next(input, { ...init, headers });
+	};
+};

--- a/packages/middleware-cookies/tsconfig.json
+++ b/packages/middleware-cookies/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"outDir": "dist",
+		"rootDir": "src"
+	},
+	"include": ["src/**/*"]
+}

--- a/packages/middleware-cookies/tsdown.config.ts
+++ b/packages/middleware-cookies/tsdown.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig([
+	{
+		globalName: "QFM_cookies",
+		platform: "neutral",
+		target: "es2020",
+		format: ["cjs", "esm", "iife"],
+		sourcemap: true,
+		minify: true,
+	},
+]);

--- a/packages/middleware-cookies/turbo.json
+++ b/packages/middleware-cookies/turbo.json
@@ -1,0 +1,5 @@
+{
+	"$schema": "https://turborepo.com/schema.json",
+	"extends": ["//"],
+	"tasks": {}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,21 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
 
+  packages/middleware-cookies:
+    devDependencies:
+      '@qfetch/core':
+        specifier: 'workspace:'
+        version: link:../core
+      '@qfetch/test-utils':
+        specifier: 'workspace:'
+        version: link:../test-utils
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.15.12(typescript@5.9.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+
   packages/middleware-retry-after:
     dependencies:
       '@proventuslabs/retry-strategies':

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -43,6 +43,15 @@
 					"jsonpath": "$.version"
 				}
 			]
+		},
+		"packages/middleware-cookies": {
+			"extra-files": [
+				{
+					"type": "json",
+					"path": "jsr.json",
+					"jsonpath": "$.version"
+				}
+			]
 		}
 	}
 }


### PR DESCRIPTION
Fetch middleware for setting cookies on outgoing requests.

Closes #48.