### PR TITLE
docs: move includeVersion to per-package typedoc.json

### DIFF
--- a/packages/core/typedoc.json
+++ b/packages/core/typedoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://typedoc.org/schema.json",
+	"includeVersion": true
+}

--- a/packages/middleware-authorization/typedoc.json
+++ b/packages/middleware-authorization/typedoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://typedoc.org/schema.json",
+	"includeVersion": true
+}

--- a/packages/middleware-base-url/typedoc.json
+++ b/packages/middleware-base-url/typedoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://typedoc.org/schema.json",
+	"includeVersion": true
+}

--- a/packages/middleware-headers/typedoc.json
+++ b/packages/middleware-headers/typedoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://typedoc.org/schema.json",
+	"includeVersion": true
+}

--- a/packages/middleware-query-params/typedoc.json
+++ b/packages/middleware-query-params/typedoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://typedoc.org/schema.json",
+	"includeVersion": true
+}

--- a/packages/middleware-retry-after/typedoc.json
+++ b/packages/middleware-retry-after/typedoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://typedoc.org/schema.json",
+	"includeVersion": true
+}

--- a/packages/middleware-retry-status/typedoc.json
+++ b/packages/middleware-retry-status/typedoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://typedoc.org/schema.json",
+	"includeVersion": true
+}

--- a/packages/middlewares/typedoc.json
+++ b/packages/middlewares/typedoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://typedoc.org/schema.json",
+	"includeVersion": true
+}

--- a/packages/qfetch/typedoc.json
+++ b/packages/qfetch/typedoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://typedoc.org/schema.json",
+	"includeVersion": true
+}

--- a/turbo/templates/middleware/typedoc.json
+++ b/turbo/templates/middleware/typedoc.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://typedoc.org/schema.json",
+	"includeVersion": true
+}

--- a/typedoc.json
+++ b/typedoc.json
@@ -10,12 +10,10 @@
 		"packages/middleware-retry-after",
 		"packages/middleware-retry-status",
 		"packages/middlewares",
-		"packages/qfetch",
-		"packages/test-utils"
+		"packages/qfetch"
 	],
 	"out": "docs",
 	"name": "qfetch",
-	"includeVersion": true,
 	"readme": "README.md",
 	"githubPages": true,
 	"navigation": {


### PR DESCRIPTION
## Summary

- Remove test-utils from docs (internal package)
- Add `typedoc.json` with `includeVersion: true` to each public package
- Add `typedoc.json` to middleware template for new packages

Each package now controls its own version display in the generated docs.