### PR TITLE
docs: trigger on release publish instead of workflow_run

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,12 +1,9 @@
 name: Documentation
 
 on:
-  workflow_run:
-    workflows: ["Packages CD"]
+  release:
     types:
-      - completed
-    branches:
-      - main
+      - published
   workflow_dispatch:
 
 permissions:
@@ -22,7 +19,6 @@ jobs:
   build:
     timeout-minutes: 5
     runs-on: ubuntu-24.04
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

Only rebuild docs when a package is actually released, not on every push to main.

Changes `workflow_run` trigger to `release: published` event.