### PR TITLE
feat(middlewares,qfetch): add middleware-response-error to aggregate packages

### DIFF
--- a/packages/middlewares/package.json
+++ b/packages/middlewares/package.json
@@ -9,6 +9,7 @@
 		"@qfetch/middleware-base-url": "workspace:^",
 		"@qfetch/middleware-headers": "workspace:^",
 		"@qfetch/middleware-query-params": "workspace:^",
+		"@qfetch/middleware-response-error": "workspace:^",
 		"@qfetch/middleware-retry-after": "workspace:^",
 		"@qfetch/middleware-retry-status": "workspace:^"
 	},
@@ -37,6 +38,7 @@
 		"http",
 		"middleware",
 		"query-params",
+		"response-error",
 		"retry",
 		"typescript"
 	],

--- a/packages/middlewares/src/index.ts
+++ b/packages/middlewares/src/index.ts
@@ -10,12 +10,14 @@
  *   withBaseUrl,
  *   withHeaders,
  *   withQueryParams,
+ *   withResponseError,
  *   withRetryAfter,
  *   withRetryStatus,
  * } from "@qfetch/middlewares";
  * import { compose } from "@qfetch/core";
  *
  * const qfetch = compose(
+ *   withResponseError(),
  *   withRetryStatus({ statuses: [500, 502, 503] }),
  *   withRetryAfter(),
  *   withHeaders({ "Content-Type": "application/json" }),
@@ -28,5 +30,6 @@ export * from "@qfetch/middleware-authorization";
 export * from "@qfetch/middleware-base-url";
 export * from "@qfetch/middleware-headers";
 export * from "@qfetch/middleware-query-params";
+export * from "@qfetch/middleware-response-error";
 export * from "@qfetch/middleware-retry-after";
 export * from "@qfetch/middleware-retry-status";

--- a/packages/qfetch/package.json
+++ b/packages/qfetch/package.json
@@ -10,6 +10,7 @@
 		"@qfetch/middleware-base-url": "workspace:^",
 		"@qfetch/middleware-headers": "workspace:^",
 		"@qfetch/middleware-query-params": "workspace:^",
+		"@qfetch/middleware-response-error": "workspace:^",
 		"@qfetch/middleware-retry-after": "workspace:^",
 		"@qfetch/middleware-retry-status": "workspace:^"
 	},
@@ -38,6 +39,7 @@
 		"http",
 		"middleware",
 		"query-params",
+		"response-error",
 		"retry",
 		"typescript"
 	],

--- a/packages/qfetch/src/index.ts
+++ b/packages/qfetch/src/index.ts
@@ -11,11 +11,13 @@
  *   withBaseUrl,
  *   withHeaders,
  *   withQueryParams,
+ *   withResponseError,
  *   withRetryAfter,
  *   withRetryStatus,
  * } from "@qfetch/qfetch";
  *
  * const qfetch = compose(
+ *   withResponseError(),
  *   withRetryStatus({ statuses: [500, 502, 503] }),
  *   withRetryAfter(),
  *   withHeaders({ "Content-Type": "application/json" }),
@@ -31,5 +33,6 @@ export * from "@qfetch/middleware-authorization";
 export * from "@qfetch/middleware-base-url";
 export * from "@qfetch/middleware-headers";
 export * from "@qfetch/middleware-query-params";
+export * from "@qfetch/middleware-response-error";
 export * from "@qfetch/middleware-retry-after";
 export * from "@qfetch/middleware-retry-status";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,6 +185,9 @@ importers:
       '@qfetch/middleware-query-params':
         specifier: workspace:^
         version: link:../middleware-query-params
+      '@qfetch/middleware-response-error':
+        specifier: workspace:^
+        version: link:../middleware-response-error
       '@qfetch/middleware-retry-after':
         specifier: workspace:^
         version: link:../middleware-retry-after
@@ -216,6 +219,9 @@ importers:
       '@qfetch/middleware-query-params':
         specifier: workspace:^
         version: link:../middleware-query-params
+      '@qfetch/middleware-response-error':
+        specifier: workspace:^
+        version: link:../middleware-response-error
       '@qfetch/middleware-retry-after':
         specifier: workspace:^
         version: link:../middleware-retry-after


### PR DESCRIPTION
## Summary

Adds `@qfetch/middleware-response-error` to the aggregate packages:
- `@qfetch/middlewares` - re-exports all middlewares
- `@qfetch/qfetch` - re-exports core + all middlewares

**Changes:**
- Added dependency on `@qfetch/middleware-response-error`
- Added re-export in index.ts
- Updated JSDoc examples to include `withResponseError`
- Added "response-error" keyword

## Depends on

- #69 (must be merged first)