### PR TITLE
refactor(middlewares): slim READMEs and refactor core types for TypeDoc

### DIFF
--- a/packages/core/src/framework.integration-test.ts
+++ b/packages/core/src/framework.integration-test.ts
@@ -2,7 +2,7 @@ import { describe, suite, type TestContext, test } from "node:test";
 
 import { createTestServer, type RequestHandler } from "@qfetch/test-utils";
 
-import { compose, type FetchExecutor, pipeline } from "./framework.ts";
+import { compose, type MiddlewareExecutor, pipeline } from "./framework.ts";
 
 /* node:coverage disable */
 
@@ -36,14 +36,14 @@ suite("framework - Integration", { concurrency: true }, () => {
 
 			const calls: string[] = [];
 
-			const mw1: FetchExecutor = (next) => async (input, init) => {
+			const mw1: MiddlewareExecutor = (next) => async (input, init) => {
 				calls.push("mw1-before");
 				const res = await next(input, init);
 				calls.push("mw1-after");
 				return res;
 			};
 
-			const mw2: FetchExecutor = (next) => async (input, init) => {
+			const mw2: MiddlewareExecutor = (next) => async (input, init) => {
 				calls.push("mw2-before");
 				const res = await next(input, init);
 				calls.push("mw2-after");
@@ -72,7 +72,7 @@ suite("framework - Integration", { concurrency: true }, () => {
 			ctx.plan(2);
 			const { baseUrl } = await createTestServer(ctx, frameworkTestHandler);
 
-			const addHeader: FetchExecutor = (next) => async (input, init) => {
+			const addHeader: MiddlewareExecutor = (next) => async (input, init) => {
 				const headers = new Headers(init?.headers);
 				headers.set("X-Custom-Header", "test-value");
 				return next(input, { ...init, headers });
@@ -125,14 +125,14 @@ suite("framework - Integration", { concurrency: true }, () => {
 
 			const calls: string[] = [];
 
-			const mw1: FetchExecutor = (next) => async (input, init) => {
+			const mw1: MiddlewareExecutor = (next) => async (input, init) => {
 				calls.push("mw1-before");
 				const res = await next(input, init);
 				calls.push("mw1-after");
 				return res;
 			};
 
-			const mw2: FetchExecutor = (next) => async (input, init) => {
+			const mw2: MiddlewareExecutor = (next) => async (input, init) => {
 				calls.push("mw2-before");
 				const res = await next(input, init);
 				calls.push("mw2-after");
@@ -161,7 +161,7 @@ suite("framework - Integration", { concurrency: true }, () => {
 			ctx.plan(2);
 			const { baseUrl } = await createTestServer(ctx, frameworkTestHandler);
 
-			const addHeader: FetchExecutor = (next) => async (input, init) => {
+			const addHeader: MiddlewareExecutor = (next) => async (input, init) => {
 				const headers = new Headers(init?.headers);
 				headers.set("X-Custom-Header", "pipeline-value");
 				return next(input, { ...init, headers });

--- a/packages/core/src/framework.test.ts
+++ b/packages/core/src/framework.test.ts
@@ -1,6 +1,6 @@
 import { describe, suite, type TestContext, test } from "node:test";
 
-import { compose, type FetchExecutor, pipeline } from "./framework.ts";
+import { compose, type MiddlewareExecutor, pipeline } from "./framework.ts";
 
 /* node:coverage disable */
 suite("framework - Unit", () => {
@@ -10,14 +10,14 @@ suite("framework - Unit", () => {
 			ctx.plan(2);
 			const calls: string[] = [];
 
-			const mw1: FetchExecutor = (next) => async (input, init) => {
+			const mw1: MiddlewareExecutor = (next) => async (input, init) => {
 				calls.push("mw1-before");
 				const res = await next(input, init);
 				calls.push("mw1-after");
 				return res;
 			};
 
-			const mw2: FetchExecutor = (next) => async (input, init) => {
+			const mw2: MiddlewareExecutor = (next) => async (input, init) => {
 				calls.push("mw2-before");
 				const res = await next(input, init);
 				calls.push("mw2-after");
@@ -59,7 +59,7 @@ suite("framework - Unit", () => {
 				return new Response("ok");
 			});
 
-			const passthrough: FetchExecutor = (next) => (input, init) =>
+			const passthrough: MiddlewareExecutor = (next) => (input, init) =>
 				next(input, init);
 
 			const qfetch = compose(passthrough)(baseFetch);
@@ -104,14 +104,14 @@ suite("framework - Unit", () => {
 			ctx.plan(2);
 			const calls: string[] = [];
 
-			const mw1: FetchExecutor = (next) => async (input, init) => {
+			const mw1: MiddlewareExecutor = (next) => async (input, init) => {
 				calls.push("mw1-before");
 				const res = await next(input, init);
 				calls.push("mw1-after");
 				return res;
 			};
 
-			const mw2: FetchExecutor = (next) => async (input, init) => {
+			const mw2: MiddlewareExecutor = (next) => async (input, init) => {
 				calls.push("mw2-before");
 				const res = await next(input, init);
 				calls.push("mw2-after");
@@ -153,7 +153,7 @@ suite("framework - Unit", () => {
 				return new Response("ok");
 			});
 
-			const passthrough: FetchExecutor = (next) => (input, init) =>
+			const passthrough: MiddlewareExecutor = (next) => (input, init) =>
 				next(input, init);
 
 			const qfetch = pipeline(passthrough)(baseFetch);

--- a/packages/middleware-authorization/README.md
+++ b/packages/middleware-authorization/README.md
@@ -1,14 +1,12 @@
 # @qfetch/middleware-authorization
 
-Fetch middleware for automatic `Authorization` header injection with retry on `401 Unauthorized` responses.
+Fetch middleware for automatic `Authorization` header injection with retry on `401 Unauthorized`.
 
 ## Overview
 
-Automatically injects `Authorization` headers using a flexible `TokenProvider` interface. When a `401 Unauthorized` response is received, the middleware refreshes the token and retries according to the configured backoff strategy.
+Injects `Authorization` headers using a flexible `TokenProvider` interface. When a `401 Unauthorized` response is received, the middleware refreshes the token and retries according to the configured backoff strategy. Supports any authorization scheme (Bearer, Basic, Token, etc.).
 
-Use configurable backoff strategies from [`@proventuslabs/retry-strategies`](https://jsr.io/@proventuslabs/retry-strategies) to control retry delays and limits.
-
-Intended for use with the composable middleware system provided by [`@qfetch/core`](https://github.com/qfetch/qfetch/tree/main/packages/core#readme).
+Intended for use with [`@qfetch/core`](https://github.com/qfetch/qfetch/tree/main/packages/core#readme).
 
 ## Installation
 
@@ -16,74 +14,40 @@ Intended for use with the composable middleware system provided by [`@qfetch/cor
 npm install @qfetch/middleware-authorization @proventuslabs/retry-strategies
 ```
 
-## API
-
-### `withAuthorization(options)`
-
-Creates a middleware that injects authorization headers and retries on 401 responses.
-
-#### Options
-
-- `tokenProvider: TokenProvider` **(required)** - Provider instance that supplies authorization credentials
-  - Called before each request to retrieve the current token
-  - Called again before each retry attempt, allowing token refresh
-  - Must return an object with `accessToken` (string) and `tokenType` (string) properties
-- `strategy: () => BackoffStrategy` **(required)** - Factory function that creates a backoff strategy for retry delays
-  - The strategy determines how long to wait between retry attempts
-  - Controls when to stop retrying by returning `NaN`
-  - A new strategy instance is created for each request chain
-  - Use `upto()` wrapper from `@proventuslabs/retry-strategies` to limit retry attempts
-
-#### Types
+## Quick Start
 
 ```typescript
-type TokenProvider = {
-  getToken(): Promise<AuthorizationToken>;
-};
+import { withAuthorization } from '@qfetch/middleware-authorization';
+import { withBaseUrl } from '@qfetch/middleware-base-url';
+import { withResponseError } from '@qfetch/middleware-response-error';
+import { constant, upto } from '@proventuslabs/retry-strategies';
+import { compose } from '@qfetch/core';
 
-type AuthorizationToken = {
-  accessToken: string; // The credential value (e.g., JWT, API key)
-  tokenType: string;   // The authorization scheme (e.g., "Bearer", "Basic")
-};
+// Token provider that refreshes on 401 retry
+let accessToken = 'initial-token';
+
+const api = compose(
+  withResponseError(),
+  withAuthorization({
+    tokenProvider: {
+      getToken: async () => {
+        // On retry after 401, this fetches a fresh token
+        return { accessToken, tokenType: 'Bearer' };
+      },
+    },
+    // Retry once immediately on 401
+    strategy: () => upto(1, constant(0)),
+  }),
+  withBaseUrl('https://api.example.com/v1/'),
+)(fetch);
+
+// Automatic auth header injection and 401 retry
+const user = await api('me').then(r => r.json());
 ```
 
-#### Behavior
+## Documentation
 
-- **Header injection** - Calls `tokenProvider.getToken()` and constructs the `Authorization` header as `<tokenType> <accessToken>`
-- **Existing headers** - Respects existing `Authorization` headers and does not override them; token provider is not called when header already exists
-- **401 retry** - On `401 Unauthorized` responses, refreshes the token and retries according to the strategy
-- **Request body cleanup** - Automatically cancels the response body stream before retrying to prevent memory leaks
-- **Error handling**:
-  - Token provider errors propagate directly to the caller
-  - Invalid tokens (missing properties) throw `TypeError`
-  - Exceeding INT32_MAX (~24.8 days) for delay throws `RangeError`
-- **Cancellation support** - Respects `AbortSignal` passed via request options or `Request` object
-
-## Usage
-
-```typescript
-import { withAuthorization } from "@qfetch/middleware-authorization";
-import { constant, upto } from "@proventuslabs/retry-strategies";
-
-const qfetch = withAuthorization({
-  tokenProvider: {
-    getToken: async () => ({
-      accessToken: "my-api-token",
-      tokenType: "Bearer",
-    }),
-  },
-  strategy: () => upto(1, constant(0)),
-})(fetch);
-
-await qfetch("https://api.example.com/data");
-```
-
-## Notes
-
-- Supports any authorization scheme: `Bearer`, `Basic`, `Token`, or custom schemes
-- Only `401` status triggers retry; other error statuses pass through unchanged
-- Does not handle concurrent request token refresh coordination—implement in your `TokenProvider` if needed
-- Works with string URLs, `URL` objects, and `Request` objects
+For complete API reference, examples, and type definitions, see the [API documentation](https://qfetch.github.io/qfetch/modules/_qfetch_middleware_authorization.html).
 
 ## Standards References
 

--- a/packages/middleware-authorization/src/with-authorization.ts
+++ b/packages/middleware-authorization/src/with-authorization.ts
@@ -71,7 +71,7 @@ export type AuthorizationToken = {
  * }
  * ```
  */
-export type TokenProvider = {
+export interface TokenProvider {
 	/**
 	 * Retrieves the current authorization credentials.
 	 *
@@ -82,7 +82,7 @@ export type TokenProvider = {
 	 * @throws If token retrieval fails, the error propagates to the caller.
 	 */
 	getToken(): Promise<AuthorizationToken>;
-};
+}
 
 /**
  * Configuration options for the {@link withAuthorization} middleware.

--- a/packages/middleware-authorization/src/with-authorization.ts
+++ b/packages/middleware-authorization/src/with-authorization.ts
@@ -1,5 +1,5 @@
 import { type BackoffStrategy, waitFor } from "@proventuslabs/retry-strategies";
-import type { Middleware } from "@qfetch/core";
+import type { MiddlewareExecutor } from "@qfetch/core";
 
 /**
  * Token credentials returned by a {@link TokenProvider}.
@@ -168,9 +168,9 @@ export type AuthorizationOptions = {
  * @see {@link https://www.rfc-editor.org/rfc/rfc9110.html#name-401-unauthorized RFC 9110 - 401 Unauthorized}
  * @see {@link https://www.rfc-editor.org/rfc/rfc6750.html RFC 6750 - Bearer Token Usage}
  */
-export const withAuthorization: Middleware<[opts: AuthorizationOptions]> = (
-	opts,
-) => {
+export function withAuthorization(
+	opts: AuthorizationOptions,
+): MiddlewareExecutor {
 	const { tokenProvider } = opts;
 
 	return (next) => async (input, init) => {
@@ -219,7 +219,7 @@ export const withAuthorization: Middleware<[opts: AuthorizationOptions]> = (
 
 		return response;
 	};
-};
+}
 
 /**
  * Prepares a RequestInit with the Authorization header injected.

--- a/packages/middleware-base-url/README.md
+++ b/packages/middleware-base-url/README.md
@@ -1,22 +1,12 @@
 # @qfetch/middleware-base-url
 
-Fetch middleware for automatically resolving URLs against a configured base URL.
+Fetch middleware for resolving URLs against a configured base URL.
 
 ## Overview
 
-Automatically resolves **string** request URLs against a configured base URL following standard URL constructor behavior:
+Resolves string request URLs against a base URL using the WHATWG URL Standard (`new URL(input, base)`). Relative URLs are resolved, absolute paths replace the pathname, and absolute URLs with schemes bypass the base entirely. URL and Request objects pass through unchanged.
 
-**String inputs (resolved using `new URL(input, base)`):**
-- **Relative URLs** (like `"users"`) → resolved against the base URL
-- **Absolute paths** (like `"/users"`) → replaces the base URL's pathname (keeps protocol + host from base)
-- **Absolute URLs with scheme** (like `"https://example.com/data"`) → ignores the base URL entirely
-
-**URL objects and Request objects:**
-- Passed through unchanged, as they already contain absolute URLs
-
-This middleware strictly follows the [URL Standard](https://url.spec.whatwg.org/) for predictable and standards-compliant behavior.
-
-Intended for use with the composable middleware system provided by [`@qfetch/core`](https://github.com/qfetch/qfetch/tree/main/packages/core#readme).
+Intended for use with [`@qfetch/core`](https://github.com/qfetch/qfetch/tree/main/packages/core#readme).
 
 ## Installation
 
@@ -24,66 +14,32 @@ Intended for use with the composable middleware system provided by [`@qfetch/cor
 npm install @qfetch/middleware-base-url
 ```
 
-## API
-
-### `withBaseUrl(baseUrl)`
-
-Creates a middleware that resolves request URLs against the given base URL using standard URL resolution.
-
-#### Parameters
-
-- `baseUrl` (`string | URL`) - The base URL to resolve requests against
-  - Accepts either a string or URL instance
-  - Must be a valid URL (throws `TypeError` if invalid)
-  - Trailing slash recommended for predictable path resolution
-  - Example: `"https://api.example.com/v1/"` or `new URL("https://api.example.com/v1/")`
-
-#### Behavior
-
-The middleware only applies base URL resolution to **string inputs**, following the URL constructor standard behavior:
-
-**String inputs (resolved using `new URL(input, base)`):**
-- **Relative URLs** (e.g., `"users"`) → resolved against the base URL
-- **Absolute paths** (e.g., `"/users"`) → replaces the base URL's pathname (keeps protocol + host from base)
-- **Absolute URLs with scheme** (e.g., `"https://..."`) → ignores the base URL entirely
-
-**URL objects:**
-- Passed through unchanged (already contain absolute URLs)
-
-**Request objects:**
-- Passed through unchanged (already contain absolute URLs)
-
-**General behavior:**
-- **Type preservation** - Input types are preserved (string→string, URL→URL, Request→Request)
-- **Query parameters and fragments** - Always preserved during URL resolution
-
-## Usage
+## Quick Start
 
 ```typescript
 import { withBaseUrl } from '@qfetch/middleware-base-url';
+import { withHeaders } from '@qfetch/middleware-headers';
+import { compose } from '@qfetch/core';
 
-const qfetch = withBaseUrl('https://api.example.com/v1/')(fetch);
+// Environment-aware API client
+const apiBaseUrl = process.env.API_URL ?? 'https://api.example.com/v1/';
 
-// Relative URLs → resolved against base
-await qfetch('users');  // → https://api.example.com/v1/users
+const api = compose(
+  withHeaders({ 'Accept': 'application/json' }),
+  withBaseUrl(apiBaseUrl),
+)(fetch);
 
-// Absolute paths → replaces pathname (keeps protocol + host)
-await qfetch('/users'); // → https://api.example.com/users
-
-// Absolute URLs with scheme → base ignored
-await qfetch('https://external.com/data'); // → https://external.com/data
+// Use relative paths throughout your application
+const users = await api('users').then(r => r.json());
+const user = await api('users/123').then(r => r.json());
+const posts = await api('posts?limit=10').then(r => r.json());
 ```
 
+## Documentation
 
-## Notes
-
-- Only **string inputs** are resolved; `URL` and `Request` objects pass through unchanged
-- Resolution follows WHATWG URL Standard: `new URL(input, base)`
-- Trailing slash recommended: `"v1/"` appends paths, `"v1"` replaces the last segment
-- Query parameters and fragments are always preserved
+For complete API reference, examples, and type definitions, see the [API documentation](https://qfetch.github.io/qfetch/modules/_qfetch_middleware_base_url.html).
 
 ## Standards References
 
 - [WHATWG URL Standard](https://url.spec.whatwg.org/) - Defines URL resolution behavior
 - [MDN: URL API](https://developer.mozilla.org/en-US/docs/Web/API/URL) - Browser implementation documentation
-- [Fetch Standard](https://fetch.spec.whatwg.org/) - Defines Request and fetch API semantics

--- a/packages/middleware-base-url/src/with-base-url.ts
+++ b/packages/middleware-base-url/src/with-base-url.ts
@@ -1,4 +1,4 @@
-import type { Middleware } from "@qfetch/core";
+import type { MiddlewareExecutor } from "@qfetch/core";
 
 /**
  * Middleware that resolves string fetch requests against a base URL.
@@ -36,7 +36,7 @@ import type { Middleware } from "@qfetch/core";
  * @see {@link https://url.spec.whatwg.org/ WHATWG URL Standard}
  * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/URL MDN: URL API}
  */
-export const withBaseUrl: Middleware<[baseUrl: string | URL]> = (baseUrl) => {
+export function withBaseUrl(baseUrl: string | URL): MiddlewareExecutor {
 	const base = new URL(baseUrl);
 
 	return (next) => async (input, init) => {
@@ -48,4 +48,4 @@ export const withBaseUrl: Middleware<[baseUrl: string | URL]> = (baseUrl) => {
 
 		return next(input, init);
 	};
-};
+}

--- a/packages/middleware-headers/README.md
+++ b/packages/middleware-headers/README.md
@@ -4,20 +4,9 @@ Fetch middleware for adding default headers to outgoing requests.
 
 ## Overview
 
-Sets default headers on outgoing requests using the standard `Headers` API. Request headers take precedence over middleware headers - if a header already exists in the request, the middleware header is not applied.
+Sets default headers on outgoing requests using the standard `Headers` API. Request headers take precedence over middleware headers. Supports both plain objects and `Headers` instances. Header names are case-insensitive per HTTP specification.
 
-**Input formats:**
-- **Plain object** → `{ "Content-Type": "application/json" }`
-- **Headers instance** → `new Headers({ "Content-Type": "application/json" })`
-
-**Header handling:**
-- Header names are case-insensitive per HTTP specification
-- Request headers take precedence (no override)
-- Empty headers object `{}` passes request through unchanged
-
-This middleware follows the [HTTP/1.1 specification](https://www.rfc-editor.org/rfc/rfc9110.html#name-header-fields) for header field handling.
-
-Intended for use with the composable middleware system provided by [`@qfetch/core`](https://github.com/qfetch/qfetch/tree/main/packages/core#readme).
+Intended for use with [`@qfetch/core`](https://github.com/qfetch/qfetch/tree/main/packages/core#readme).
 
 ## Installation
 
@@ -25,113 +14,36 @@ Intended for use with the composable middleware system provided by [`@qfetch/cor
 npm install @qfetch/middleware-headers
 ```
 
-## API
-
-### `withHeader(name, value)`
-
-Creates a middleware that adds a single header to outgoing requests.
-
-#### Parameters
-
-- `name` (`string`) **(required)** - The header name
-- `value` (`string`) **(required)** - The header value
-
-### `withHeaders(headers)`
-
-Creates a middleware that adds multiple headers to outgoing requests.
-
-#### Parameters
-
-- `headers` (`HeadersInput`) **(required)** - Headers to add
-  - Plain object: `Record<string, string>`
-  - Headers instance: `Headers`
-
-### Types
+## Quick Start
 
 ```typescript
-type HeaderEntries = Record<string, string>;
-type HeadersInput = HeaderEntries | Headers;
-```
-
-#### Behavior
-
-- **Case-insensitive** - Header names are case-insensitive per HTTP specification
-- **No override** - Request headers take precedence over middleware headers
-- **Fast path** - Empty headers object passes request through unchanged
-- **Standard API** - Uses the native `Headers` API for proper handling
-
-## Usage
-
-```typescript
-import { withHeader, withHeaders } from '@qfetch/middleware-headers';
-
-// Single header
-const qfetch = withHeader('Content-Type', 'application/json')(fetch);
-await qfetch('https://api.example.com/users');
-// Request includes: Content-Type: application/json
-
-// Multiple headers
-const qfetch = withHeaders({
-  'Content-Type': 'application/json',
-  'Accept': 'application/json',
-  'X-Request-ID': 'abc123'
-})(fetch);
-await qfetch('https://api.example.com/users');
-
-// Using Headers instance
-const defaultHeaders = new Headers();
-defaultHeaders.set('Content-Type', 'application/json');
-defaultHeaders.set('Accept', 'application/json');
-
-const qfetch = withHeaders(defaultHeaders)(fetch);
-```
-
-### Request Headers Take Precedence
-
-```typescript
-const qfetch = withHeader('Content-Type', 'application/json')(fetch);
-
-// Request header overrides middleware header
-await qfetch('https://api.example.com/users', {
-  headers: { 'Content-Type': 'text/plain' }
-});
-// Request uses: Content-Type: text/plain (request value wins)
-```
-
-### Composition with Other Middlewares
-
-```typescript
-import { withHeaders, withHeader } from '@qfetch/middleware-headers';
+import { withHeaders } from '@qfetch/middleware-headers';
 import { withBaseUrl } from '@qfetch/middleware-base-url';
+import { withAuthorization } from '@qfetch/middleware-authorization';
 import { compose } from '@qfetch/core';
 
-const qfetch = compose(
+// Build an API client with default headers for JSON communication
+const api = compose(
   withHeaders({
     'Content-Type': 'application/json',
-    'Accept': 'application/json'
+    'Accept': 'application/json',
+    'X-Client-Version': '1.0.0',
   }),
-  withBaseUrl('https://api.example.com/v1/')
+  withBaseUrl('https://api.example.com/v1/'),
 )(fetch);
 
-await qfetch('users');
-// → https://api.example.com/v1/users with headers
-
-// Composing multiple single headers
-const qfetch = compose(
-  withHeader('Content-Type', 'application/json'),
-  withHeader('Accept', 'application/json')
-)(fetch);
+// All requests include the default headers
+await api('users', {
+  method: 'POST',
+  body: JSON.stringify({ name: 'Alice' }),
+});
 ```
 
-## Notes
+## Documentation
 
-- Request headers always take precedence over middleware headers
-- Header names are case-insensitive (`Content-Type` and `content-type` are the same)
-- Empty headers object `{}` passes requests through unchanged (fast path)
-- Works with string URLs, URL objects, and Request objects
+For complete API reference, examples, and type definitions, see the [API documentation](https://qfetch.github.io/qfetch/modules/_qfetch_middleware_headers.html).
 
 ## Standards References
 
 - [RFC 9110 - HTTP Semantics: Header Fields](https://www.rfc-editor.org/rfc/rfc9110.html#name-header-fields) - HTTP header field specification
 - [MDN: Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers) - Browser implementation documentation
-- [Fetch Standard](https://fetch.spec.whatwg.org/) - Defines Request and fetch API semantics

--- a/packages/middleware-headers/src/with-headers.ts
+++ b/packages/middleware-headers/src/with-headers.ts
@@ -191,6 +191,7 @@ const mergeHeaders = (
  * ```
  *
  * @see {@link withHeaders} for setting multiple headers at once
+ * @see {@link https://www.rfc-editor.org/rfc/rfc9110.html#name-header-fields RFC 9110 - Header Fields}
  * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Headers MDN: Headers}
  */
 export const withHeader: Middleware<[name: string, value: string]> = (
@@ -277,6 +278,7 @@ export const withHeader: Middleware<[name: string, value: string]> = (
  * ```
  *
  * @see {@link withHeader} for setting a single header
+ * @see {@link https://www.rfc-editor.org/rfc/rfc9110.html#name-header-fields RFC 9110 - Header Fields}
  * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Headers MDN: Headers}
  */
 export const withHeaders: Middleware<[headers: HeadersInput]> = (headers) => {

--- a/packages/middleware-headers/src/with-headers.ts
+++ b/packages/middleware-headers/src/with-headers.ts
@@ -1,4 +1,4 @@
-import type { Middleware } from "@qfetch/core";
+import type { MiddlewareExecutor } from "@qfetch/core";
 
 /**
  * Header entries as name-value pairs.
@@ -154,7 +154,7 @@ const mergeHeaders = (
  *
  * @param name - The header name
  * @param value - The header value
- * @returns A fetch executor that adds the header to requests
+ * @returns A middleware executor that adds the header to requests
  *
  * @example
  * ```ts
@@ -194,10 +194,7 @@ const mergeHeaders = (
  * @see {@link https://www.rfc-editor.org/rfc/rfc9110.html#name-header-fields RFC 9110 - Header Fields}
  * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Headers MDN: Headers}
  */
-export const withHeader: Middleware<[name: string, value: string]> = (
-	name,
-	value,
-) => {
+export function withHeader(name: string, value: string): MiddlewareExecutor {
 	return (next) => async (input, init) => {
 		// Skip if header already exists in request
 		if (hasHeader(input, init, name)) {
@@ -207,7 +204,7 @@ export const withHeader: Middleware<[name: string, value: string]> = (
 		const mergedInit = mergeHeaders(input, init, { [name]: value });
 		return next(input, mergedInit);
 	};
-};
+}
 
 /**
  * Middleware that adds multiple headers to outgoing fetch requests.
@@ -231,7 +228,7 @@ export const withHeader: Middleware<[name: string, value: string]> = (
  * - Works with both string URLs and Request objects
  *
  * @param headers - Object or Headers instance with header name-value pairs
- * @returns A fetch executor that adds the headers to requests
+ * @returns A middleware executor that adds the headers to requests
  *
  * @example
  * ```ts
@@ -281,7 +278,7 @@ export const withHeader: Middleware<[name: string, value: string]> = (
  * @see {@link https://www.rfc-editor.org/rfc/rfc9110.html#name-header-fields RFC 9110 - Header Fields}
  * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Headers MDN: Headers}
  */
-export const withHeaders: Middleware<[headers: HeadersInput]> = (headers) => {
+export function withHeaders(headers: HeadersInput): MiddlewareExecutor {
 	// Fast path: empty headers (checked at creation time, not per-request)
 	if (isHeadersEmpty(headers)) {
 		return (next) => (input, init) => next(input, init);
@@ -291,4 +288,4 @@ export const withHeaders: Middleware<[headers: HeadersInput]> = (headers) => {
 		const mergedInit = mergeHeaders(input, init, headers);
 		return next(input, mergedInit);
 	};
-};
+}

--- a/packages/middleware-query-params/README.md
+++ b/packages/middleware-query-params/README.md
@@ -4,20 +4,9 @@ Fetch middleware for adding query parameters to outgoing request URLs.
 
 ## Overview
 
-Sets default query parameters on request URLs using the standard `URLSearchParams` API. Parameters are properly encoded and merged with any existing query string, with **request parameters taking precedence** over middleware parameters.
+Sets default query parameters on request URLs using the standard `URLSearchParams` API. Parameters are properly encoded and merged with existing query strings, with request parameters taking precedence. Supports array values in both repeated key (`?tags=a&tags=b`) and bracket notation (`?tags[]=a&tags[]=b`) formats.
 
-**Input handling:**
-- **String inputs** → Returns modified string (preserves relative/absolute format)
-- **URL objects** → Returns new URL object with appended parameters
-- **Request objects** → Returns new Request with modified URL (preserves method, headers, body)
-
-**Array value formats:**
-- **Repeated keys** (default): `{ tags: ["a", "b"] }` → `?tags=a&tags=b`
-- **Bracket notation**: `{ tags: ["a", "b"] }` → `?tags[]=a&tags[]=b`
-
-This middleware strictly follows the [URL Standard](https://url.spec.whatwg.org/) for encoding via `URLSearchParams`.
-
-Intended for use with the composable middleware system provided by [`@qfetch/core`](https://github.com/qfetch/qfetch/tree/main/packages/core#readme).
+Intended for use with [`@qfetch/core`](https://github.com/qfetch/qfetch/tree/main/packages/core#readme).
 
 ## Installation
 
@@ -25,110 +14,37 @@ Intended for use with the composable middleware system provided by [`@qfetch/cor
 npm install @qfetch/middleware-query-params
 ```
 
-## API
-
-### `withQueryParam(name, value, options?)`
-
-Creates a middleware that adds a single query parameter to outgoing requests.
-
-#### Parameters
-
-- `name` (`string`) **(required)** - The query parameter name
-- `value` (`QueryParamValue`) **(required)** - The query parameter value or array of values (encoded via URLSearchParams)
-- `options` (`QueryParamsOptions`, optional) - Configuration options
-  - `arrayFormat?: 'repeat' | 'brackets'` - How to serialize array values (default: `'repeat'`)
-
-### `withQueryParams(params, options?)`
-
-Creates a middleware that adds multiple query parameters to outgoing requests.
-
-#### Parameters
-
-- `params` (`QueryParamEntries`) **(required)** - Object with parameter name-value pairs
-  - Values can be strings or arrays of strings
-  - Empty arrays are skipped entirely
-  - Empty objects pass requests through unchanged
-- `options` (`QueryParamsOptions`, optional) - Configuration options
-  - `arrayFormat?: 'repeat' | 'brackets'` - How to serialize array values (default: `'repeat'`)
-
-### Types
-
-```typescript
-type QueryParamValue = string | string[];
-type QueryParamEntries = Record<string, QueryParamValue>;
-type QueryParamsOptions = {
-  arrayFormat?: 'repeat' | 'brackets';
-};
-```
-
-#### Behavior
-
-- **URL encoding** - Values are encoded using the standard `URLSearchParams` API, which follows the `application/x-www-form-urlencoded` format
-- **Merge behavior** - Middleware params are set first, then request params are appended (request takes precedence)
-- **Type preservation** - Input types are preserved (string→string, URL→URL, Request→Request)
-- **Relative URLs** - Handled correctly; `/api/users` stays relative after adding params
-
-## Usage
-
-```typescript
-import { withQueryParam, withQueryParams } from '@qfetch/middleware-query-params';
-
-// Single parameter
-const qfetch = withQueryParam('version', 'v2')(fetch);
-await qfetch('https://api.example.com/users');
-// → https://api.example.com/users?version=v2
-
-// Multiple parameters
-const qfetch = withQueryParams({
-  page: '1',
-  limit: '10',
-  sort: 'name'
-})(fetch);
-await qfetch('https://api.example.com/users');
-// → https://api.example.com/users?page=1&limit=10&sort=name
-
-// Array values (repeated keys - default)
-const qfetch = withQueryParams({
-  tags: ['typescript', 'javascript']
-})(fetch);
-await qfetch('https://api.example.com/posts');
-// → https://api.example.com/posts?tags=typescript&tags=javascript
-
-// Array values (bracket notation)
-const qfetch = withQueryParams(
-  { tags: ['typescript', 'javascript'] },
-  { arrayFormat: 'brackets' }
-)(fetch);
-await qfetch('https://api.example.com/posts');
-// → https://api.example.com/posts?tags[]=typescript&tags[]=javascript
-```
-
-### Composition with Other Middlewares
+## Quick Start
 
 ```typescript
 import { withQueryParams } from '@qfetch/middleware-query-params';
 import { withBaseUrl } from '@qfetch/middleware-base-url';
 import { compose } from '@qfetch/core';
 
-const qfetch = compose(
-  withQueryParams({ format: 'json', version: 'v2' }),
-  withBaseUrl('https://api.example.com/v1/')
+// API client with default pagination and filtering
+const api = compose(
+  withQueryParams({
+    format: 'json',
+    limit: '25',
+    fields: ['id', 'name', 'email'],  // ?fields=id&fields=name&fields=email
+  }),
+  withBaseUrl('https://api.example.com/v1/'),
 )(fetch);
 
-await qfetch('users');
-// → https://api.example.com/v1/users?format=json&version=v2
+// Fetch paginated users with defaults applied
+const users = await api('users').then(r => r.json());
+// → https://api.example.com/v1/users?format=json&limit=25&fields=id&fields=name&fields=email
+
+// Request params override defaults
+const page2 = await api('users?page=2&limit=50').then(r => r.json());
+// → ...?format=json&limit=25&fields=...&page=2&limit=50 (limit=50 takes precedence)
 ```
 
-## Notes
+## Documentation
 
-- Middleware params act as **defaults**; request params take precedence by appearing later in the query string
-- When keys overlap, both values are kept (middleware value first, request value after)
-- Empty params object `{}` passes requests through unchanged (fast path)
-- Empty arrays `[]` are skipped entirely
-- Special characters in values are automatically encoded
+For complete API reference, examples, and type definitions, see the [API documentation](https://qfetch.github.io/qfetch/modules/_qfetch_middleware_query_params.html).
 
 ## Standards References
 
 - [WHATWG URL Standard](https://url.spec.whatwg.org/) - Defines URL and URLSearchParams behavior
 - [MDN: URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) - Browser implementation documentation
-- [Fetch Standard](https://fetch.spec.whatwg.org/) - Defines Request and fetch API semantics

--- a/packages/middleware-query-params/src/with-query-params.ts
+++ b/packages/middleware-query-params/src/with-query-params.ts
@@ -1,4 +1,4 @@
-import type { Middleware } from "@qfetch/core";
+import type { MiddlewareExecutor } from "@qfetch/core";
 
 /**
  * A query parameter value - either a single string or an array of strings.
@@ -217,9 +217,11 @@ const mergeParams = (
  * @see {@link withQueryParams} for setting multiple query parameters at once
  * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams MDN: URLSearchParams}
  */
-export const withQueryParam: Middleware<
-	[name: string, value: QueryParamValue, options?: QueryParamsOptions]
-> = (name, value, options) => {
+export function withQueryParam(
+	name: string,
+	value: QueryParamValue,
+	options?: QueryParamsOptions,
+): MiddlewareExecutor {
 	const arrayFormat = options?.arrayFormat ?? "repeat";
 
 	return (next) => async (input, init) => {
@@ -239,7 +241,7 @@ export const withQueryParam: Middleware<
 
 		return next(reconstructUrl(url, isRelative), init);
 	};
-};
+}
 
 /**
  * Middleware that adds multiple query parameters to outgoing fetch requests.
@@ -331,9 +333,10 @@ export const withQueryParam: Middleware<
  * @see {@link withQueryParam} for setting a single query parameter
  * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams MDN: URLSearchParams}
  */
-export const withQueryParams: Middleware<
-	[params: QueryParamEntries, options?: QueryParamsOptions]
-> = (params, options) => {
+export function withQueryParams(
+	params: QueryParamEntries,
+	options?: QueryParamsOptions,
+): MiddlewareExecutor {
 	const arrayFormat = options?.arrayFormat ?? "repeat";
 
 	// Fast path: empty params (checked at creation time, not per-request)
@@ -363,4 +366,4 @@ export const withQueryParams: Middleware<
 
 		return next(reconstructUrl(url, isRelative), init);
 	};
-};
+}

--- a/packages/middleware-response-error/README.md
+++ b/packages/middleware-response-error/README.md
@@ -1,10 +1,12 @@
 # @qfetch/middleware-response-error
 
+Fetch middleware for throwing errors on HTTP error responses.
+
 ## Overview
 
-Middleware that automatically throws errors for HTTP responses based on their status codes. By default, throws a `ResponseError` for any response with status code >= 400. Provides flexible error customization through status-specific mappers and a default fallback, allowing consumers to standardize error handling across their application.
+Automatically throws errors for HTTP responses based on status codes. By default, throws a `ResponseError` for any response with status >= 400. Provides flexible customization through status-specific mappers and configurable thresholds, enabling standardized error handling across your application.
 
-Intended for use with the composable middleware system provided by [`@qfetch/core`](https://github.com/qfetch/qfetch/tree/main/packages/core#readme).
+Intended for use with [`@qfetch/core`](https://github.com/qfetch/qfetch/tree/main/packages/core#readme).
 
 ## Installation
 
@@ -12,150 +14,55 @@ Intended for use with the composable middleware system provided by [`@qfetch/cor
 npm install @qfetch/middleware-response-error
 ```
 
-## API
-
-### `withResponseError(opts?)`
-
-Creates a middleware that throws errors for HTTP responses based on status codes.
-
-#### Parameters
-
-- `opts` - Optional configuration object:
-  - `statusMap?: Map<number, ResponseErrorMapper>` - Maps specific status codes to custom error mappers. Takes priority over `defaultMapper`.
-  - `defaultMapper?: ResponseErrorMapper` - Creates errors for status codes not in `statusMap`. Defaults to `(response) => new ResponseError(response)`.
-  - `throwOnStatusCode?: (code: number) => boolean` - Determines whether to throw for a given status code. Defaults to `(code) => code >= 400`.
-
-#### Types
-
-```typescript
-type ResponseErrorMapper = (response: Response) => unknown | Promise<unknown>;
-```
-
-#### Returns
-
-A middleware function compatible with `@qfetch/core`.
-
-### `ResponseError`
-
-Default error class thrown for failed HTTP responses.
-
-#### Constructor
-
-```typescript
-new ResponseError(response: Response, options?: ErrorOptions)
-```
-
-- `response` - The HTTP response that triggered the error
-- `options` - Standard Error options, including `cause` for error chaining
-
-#### Properties
-
-- `status: number` - The HTTP status code
-- `statusText: string` - The HTTP status text
-- `url: string` - The URL of the failed request
-- `response: Response` - The full response object (body can still be read)
-- `message: string` - Formatted as `"HTTP {status} {statusText}: {url}"`
-- `cause?: unknown` - The underlying cause if provided via options
-
-## Usage
+## Quick Start
 
 ```typescript
 import { withResponseError, ResponseError } from '@qfetch/middleware-response-error';
+import { withRetryStatus } from '@qfetch/middleware-retry-status';
+import { withBaseUrl } from '@qfetch/middleware-base-url';
+import { upto, zero } from '@proventuslabs/retry-strategies';
+import { compose } from '@qfetch/core';
 
-// Zero-config usage - throws ResponseError for status >= 400
-const qfetch = withResponseError()(fetch);
-
-try {
-  await qfetch('https://api.example.com/users/123');
-} catch (error) {
-  if (error instanceof ResponseError) {
-    console.log(error.status);     // 404
-    console.log(error.statusText); // "Not Found"
-    console.log(error.url);        // "https://api.example.com/users/123"
-    // Read response body if needed
-    const body = await error.response.json();
-  }
-}
-```
-
-### Custom Error Mapping
-
-```typescript
-import { withResponseError } from '@qfetch/middleware-response-error';
-
+// Custom application errors
 class NotFoundError extends Error {
-  constructor(url: string) {
+  constructor(public url: string) {
     super(`Resource not found: ${url}`);
     this.name = 'NotFoundError';
   }
 }
 
-class ApiError extends Error {
-  code: string;
-  constructor(code: string, message: string) {
-    super(message);
-    this.name = 'ApiError';
-    this.code = code;
+// API client with custom error handling
+const api = compose(
+  withResponseError({
+    statusMap: new Map([
+      [404, (res) => new NotFoundError(res.url)],
+      [400, async (res) => {
+        const body = await res.json();
+        return new Error(`Validation failed: ${body.message}`);
+      }],
+    ]),
+  }),
+  withRetryStatus({ strategy: () => upto(3, zero()) }),
+  withBaseUrl('https://api.example.com/v1/'),
+)(fetch);
+
+try {
+  const user = await api('users/123').then(r => r.json());
+} catch (error) {
+  if (error instanceof NotFoundError) {
+    // Handle 404 specifically
+  } else if (error instanceof ResponseError) {
+    // Handle other HTTP errors (500, etc.)
+    console.log(error.status, error.statusText);
   }
 }
-
-const qfetch = withResponseError({
-  // Map specific status codes to custom errors
-  statusMap: new Map([
-    [404, (res) => new NotFoundError(res.url)],
-    // Async mappers can read the response body
-    [400, async (res) => {
-      const body = await res.json();
-      return new ApiError(body.code, body.message);
-    }],
-  ]),
-  // Custom default for unmapped error status codes
-  defaultMapper: async (res) => {
-    const text = await res.text();
-    return new Error(`API Error ${res.status}: ${text}`);
-  },
-})(fetch);
 ```
 
-### Conditional Throwing
+## Documentation
 
-```typescript
-import { withResponseError } from '@qfetch/middleware-response-error';
-
-// Only throw for server errors (5xx), let client errors through
-const qfetch = withResponseError({
-  throwOnStatusCode: (code) => code >= 500,
-})(fetch);
-
-const response = await qfetch('/api/validate');
-if (response.status === 400) {
-  // Handle validation errors without try/catch
-  const errors = await response.json();
-}
-```
-
-### Composition with Other Middlewares
-
-```typescript
-import { withResponseError } from '@qfetch/middleware-response-error';
-import { withRetryStatus } from '@qfetch/middleware-retry-status';
-import { compose } from '@qfetch/core';
-
-const qfetch = compose(
-  withResponseError(), // Throws after retries are exhausted
-  withRetryStatus({ strategy: () => upto(3, zero()) }),
-)(fetch);
-```
-
-## Notes
-
-- **Successful responses (status < 400)**: Pass through unchanged
-- **Error responses (status >= 400)**: Throw an error using the configured mapper
-- **Async mappers**: Fully supported for reading response body before throwing
-- **Response preservation**: The original `Response` object is preserved in `ResponseError` for later body reading
-- **Mapper errors**: If the mapper itself throws (e.g., JSON parse error), that error propagates directly without wrapping
+For complete API reference, examples, and type definitions, see the [API documentation](https://qfetch.github.io/qfetch/modules/_qfetch_middleware_response_error.html).
 
 ## Standards References
 
-- [MDN: Response.ok](https://developer.mozilla.org/en-US/docs/Web/API/Response/ok)
-- [MDN: HTTP Status Codes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status)
+- [MDN: Response.ok](https://developer.mozilla.org/en-US/docs/Web/API/Response/ok) - Response success indicator
+- [MDN: HTTP Status Codes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status) - HTTP status code reference

--- a/packages/middleware-response-error/src/with-response-error.ts
+++ b/packages/middleware-response-error/src/with-response-error.ts
@@ -1,4 +1,4 @@
-import type { Middleware } from "@qfetch/core";
+import type { MiddlewareExecutor } from "@qfetch/core";
 
 /**
  * Function that creates an error from a response.
@@ -140,9 +140,9 @@ export class ResponseError extends Error {
  * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Response/ok MDN: Response.ok}
  * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTTP/Status MDN: HTTP Status Codes}
  */
-export const withResponseError: Middleware<[opts?: ResponseErrorOptions]> = (
-	opts = {},
-) => {
+export function withResponseError(
+	opts: ResponseErrorOptions = {},
+): MiddlewareExecutor {
 	const {
 		statusMap = new Map(),
 		defaultMapper = (response) => new ResponseError(response),
@@ -163,4 +163,4 @@ export const withResponseError: Middleware<[opts?: ResponseErrorOptions]> = (
 		// Await mapper result (works for both sync and async)
 		throw await mapper(response);
 	};
-};
+}

--- a/packages/middleware-retry-after/README.md
+++ b/packages/middleware-retry-after/README.md
@@ -4,25 +4,9 @@ Fetch middleware for **server-directed** retry timing based on `Retry-After` hea
 
 ## Overview
 
-Respects server-provided retry timing for rate limiting and temporary unavailability. When a response includes a valid `Retry-After` header with a retryable status code (`429` or `503` by default), the middleware waits the server-specified duration before retrying.
+Respects server-provided retry timing for rate limiting and temporary unavailability. When a response includes a valid `Retry-After` header with a retryable status code (`429` or `503` by default), the middleware waits the server-specified duration before retrying. Supports both delay-seconds and HTTP-date formats per RFC 9110.
 
-Supports both `Retry-After` formats per [RFC 9110 §10.2.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.3):
-- **Delay-seconds**: `"120"` (wait 120 seconds)
-- **HTTP-date**: `"Wed, 21 Oct 2015 07:28:00 GMT"` (wait until timestamp)
-
-Use configurable backoff strategies from [`@proventuslabs/retry-strategies`](https://jsr.io/@proventuslabs/retry-strategies) to add optional jitter and control retry limits.
-
-Intended for use with the composable middleware system provided by [`@qfetch/core`](https://github.com/qfetch/qfetch/tree/main/packages/core#readme).
-
-## Important Limitations
-
-> **Replayable vs. Non-Replayable Bodies**  
-> Most request bodies — such as strings, `Blob`, `ArrayBuffer`, `Uint8Array`, `FormData`, and `URLSearchParams` — are **replayable**. Fetch recreates their internal body stream for each retry attempt, so these requests can be retried safely without any special handling.
-
-> **Non-Replayable Bodies (Streaming Bodies)**  
-> Requests whose body is a non-replayable type — such as `ReadableStream` — **cannot be retried** according to the Fetch specification. Attempting to retry such requests results in a `TypeError` because the body stream has already been consumed.  
->  
-> To support retries for streaming bodies, you must provide a *body factory* using a middleware downstream that creates a **fresh stream** for each retry.
+Intended for use with [`@qfetch/core`](https://github.com/qfetch/qfetch/tree/main/packages/core#readme).
 
 ## Installation
 
@@ -30,80 +14,34 @@ Intended for use with the composable middleware system provided by [`@qfetch/cor
 npm install @qfetch/middleware-retry-after @proventuslabs/retry-strategies
 ```
 
-## API
-
-### `withRetryAfter(opts)`
-
-Creates a middleware that retries failed requests based on the `Retry-After` header.
-
-#### Parameters
-
-- `opts` - Configuration object with the following properties:
-  - `strategy: () => BackoffStrategy` **(required)** - Factory function that creates a backoff strategy for retry delays
-    - The strategy determines additional delay (jitter) to add to the server-requested `Retry-After` delay
-    - Controls when to stop retrying by returning `NaN`
-    - Total wait time = `Retry-After` value + strategy backoff value
-    - A new strategy instance is created for each request chain
-    - Use `upto()` wrapper from `@proventuslabs/retry-strategies` to limit retry attempts
-    - Common strategies: `zero()` (no jitter), `fullJitter()`, `linear()`, `exponential()`
-  - `maxServerDelay?: number` - Maximum delay in milliseconds accepted from the server (default: unlimited)
-    - `0` means only allow instant retries (zero delay)
-    - Positive integers set a ceiling on the server's requested delay
-    - Negative or `NaN` values mean unlimited delay
-    - If the server's `Retry-After` value exceeds this, a `ConstraintError` is thrown
-  - `retryableStatuses?: ReadonlySet<number>` - Status codes that trigger retries (default: `new Set([429, 503])`)
-    - Only responses with these status codes and a valid `Retry-After` header will be retried
-    - Override to customize which status codes should trigger retry behavior
-    - Use an empty set (`new Set()`) to disable all automatic retries
-
-#### Behavior
-
-- **Successful responses** (status 2xx) are returned immediately, even with a `Retry-After` header
-- **Retryable statuses** - By default, only `429 Too Many Requests` or `503 Service Unavailable` trigger retry logic when a valid `Retry-After` header is present. This can be customized using the `retryableStatuses` option
-- **Retry-After parsing** - Supports both formats specified in RFC 9110:
-  - **Delay-seconds**: Integer values are interpreted as seconds to wait (e.g., `"120"`)
-  - **HTTP-date**: IMF-fixdate timestamps are interpreted as absolute retry time (e.g., `"Wed, 21 Oct 2015 07:28:00 GMT"`)
-  - Past dates result in zero-delay retry (immediate retry)
-  - Invalid or missing headers prevent retries (response returned as-is, no error thrown)
-  - Values exceeding safe integer range are treated as invalid
-- **Backoff strategy**:
-  - The strategy determines additional delay (jitter) to add to the server's requested delay
-  - Total wait time = `Retry-After` value + strategy backoff value
-  - Strategy controls when to stop retrying by returning `NaN`
-  - Use `upto()` wrapper to limit the number of retry attempts
-  - Common strategies include `zero()` (no jitter), `fullJitter()`, `linear()`, and `exponential()`
-- **Request body cleanup**:
-  - Automatically cancels the response body stream before retrying to prevent memory leaks
-  - This is a best-effort operation that won't block retries if cancellation fails
-- **Error handling**:
-  - Exceeding `maxServerDelay` throws a `DOMException` with name `"ConstraintError"`
-  - Exceeding INT32_MAX (2,147,483,647 milliseconds or ~24.8 days) for total delay throws a `RangeError`
-  - When the strategy returns `NaN`, retrying stops and the last response is returned (no error thrown)
-- **Cancellation support**:
-  - Respects `AbortSignal` passed via request options or `Request` object
-  - Cancellation during retry wait period immediately aborts and throws the abort reason
-  - Cancellation during retry request execution propagates the abort signal to the fetch call
-
-## Usage
+## Quick Start
 
 ```typescript
 import { withRetryAfter } from '@qfetch/middleware-retry-after';
+import { withBaseUrl } from '@qfetch/middleware-base-url';
+import { withResponseError } from '@qfetch/middleware-response-error';
 import { fullJitter, upto } from '@proventuslabs/retry-strategies';
+import { compose } from '@qfetch/core';
 
-const qfetch = withRetryAfter({
-  strategy: () => upto(3, fullJitter(100, 10_000))
-})(fetch);
+// Resilient API client that respects rate limits
+const api = compose(
+  withResponseError(),
+  withRetryAfter({
+    // Retry up to 3 times with jitter to prevent thundering herd
+    strategy: () => upto(3, fullJitter(100, 5_000)),
+    // Cap server-requested delays at 30 seconds
+    maxServerDelay: 30_000,
+  }),
+  withBaseUrl('https://api.example.com/v1/'),
+)(fetch);
 
-await qfetch('https://api.example.com/data');
+// Automatic retry on 429/503 with Retry-After header
+const data = await api('resource').then(r => r.json());
 ```
 
-## Notes
+## Documentation
 
-- Only retries when a valid `Retry-After` header is present (invalid or missing headers are passed through)
-- Total wait time = server's `Retry-After` delay + strategy backoff value
-- Use `zero()` to respect server delays exactly; use `fullJitter()` to add jitter and prevent thundering herd
-- Use `upto()` wrapper to limit retry attempts
-- Response bodies are automatically cancelled before retrying to prevent memory leaks
+For complete API reference, examples, and type definitions, see the [API documentation](https://qfetch.github.io/qfetch/modules/_qfetch_middleware_retry_after.html).
 
 ## Standards References
 

--- a/packages/middleware-retry-after/src/with-retry-after.ts
+++ b/packages/middleware-retry-after/src/with-retry-after.ts
@@ -1,5 +1,5 @@
 import { type BackoffStrategy, waitFor } from "@proventuslabs/retry-strategies";
-import type { Middleware } from "@qfetch/core";
+import type { MiddlewareExecutor } from "@qfetch/core";
 
 /**
  * Configuration options for the {@link withRetryAfter} middleware.
@@ -78,7 +78,7 @@ export type RetryAfterOptions = {
  *
  * @see {@link https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.3 RFC 9110 §10.2.3 - Retry-After}
  */
-export const withRetryAfter: Middleware<[opts: RetryAfterOptions]> = (opts) => {
+export function withRetryAfter(opts: RetryAfterOptions): MiddlewareExecutor {
 	const maxServerDelay =
 		typeof opts.maxServerDelay !== "number" || opts.maxServerDelay < 0
 			? NaN
@@ -137,7 +137,7 @@ export const withRetryAfter: Middleware<[opts: RetryAfterOptions]> = (opts) => {
 
 		return response;
 	};
-};
+}
 
 /**
  * The reason passed to body cancellation.

--- a/packages/middleware-retry-status/README.md
+++ b/packages/middleware-retry-status/README.md
@@ -4,23 +4,9 @@ Fetch middleware for **client-controlled** retry timing based on response status
 
 ## Overview
 
-Retries transient failures using configurable backoff strategies. When a response has a retryable status code (by default `408`, `429`, `500`, `502`, `503`, `504`), the middleware waits according to the strategy before retrying.
+Retries transient failures using configurable backoff strategies. When a response has a retryable status code (`408`, `429`, `500`, `502`, `503`, `504` by default), the middleware waits according to the strategy before retrying. Unlike `middleware-retry-after`, retry timing is entirely client-controlled.
 
-Unlike `@qfetch/middleware-retry-after`, this middleware does **not** parse `Retry-After` headers—retry timing is entirely client-controlled via the backoff strategy. Use this for general retry logic; use `middleware-retry-after` when server timing directives should be respected.
-
-Use configurable backoff strategies from [`@proventuslabs/retry-strategies`](https://jsr.io/@proventuslabs/retry-strategies) to control delay patterns (linear, exponential, jitter) and retry limits.
-
-Intended for use with the composable middleware system provided by [`@qfetch/core`](https://github.com/qfetch/qfetch/tree/main/packages/core#readme).
-
-## Important Limitations
-
-> **Replayable vs. Non-Replayable Bodies**
-> Most request bodies — such as strings, `Blob`, `ArrayBuffer`, `Uint8Array`, `FormData`, and `URLSearchParams` — are **replayable**. Fetch recreates their internal body stream for each retry attempt, so these requests can be retried safely without any special handling.
-
-> **Non-Replayable Bodies (Streaming Bodies)**
-> Requests whose body is a non-replayable type — such as `ReadableStream` — **cannot be retried** according to the Fetch specification. Attempting to retry such requests results in a `TypeError` because the body stream has already been consumed.
->
-> To support retries for streaming bodies, you must provide a *body factory* using a middleware downstream that creates a **fresh stream** for each retry.
+Intended for use with [`@qfetch/core`](https://github.com/qfetch/qfetch/tree/main/packages/core#readme).
 
 ## Installation
 
@@ -28,67 +14,32 @@ Intended for use with the composable middleware system provided by [`@qfetch/cor
 npm install @qfetch/middleware-retry-status @proventuslabs/retry-strategies
 ```
 
-## API
-
-### `withRetryStatus(opts)`
-
-Creates a middleware that retries failed requests based on response status codes.
-
-#### Parameters
-
-- `opts` - Configuration object with the following properties:
-  - `strategy: () => BackoffStrategy` **(required)** - Factory function that creates a backoff strategy for retry delays
-    - The strategy determines how long to wait between retry attempts
-    - Controls when to stop retrying by returning `NaN`
-    - A new strategy instance is created for each request chain
-    - Use `upto()` wrapper from `@proventuslabs/retry-strategies` to limit retry attempts
-    - Common strategies: `linear()`, `exponential()`, `fullJitter()`
-  - `retryableStatuses?: ReadonlySet<number>` - Status codes that trigger retries (default: `new Set([408, 429, 500, 502, 503, 504])`)
-    - Only responses with these status codes will be retried
-    - Override to customize which status codes should trigger retry behavior
-    - Use an empty set (`new Set()`) to disable all automatic retries
-
-#### Behavior
-
-- **Successful responses** (status 2xx) are returned immediately without retrying
-- **Retryable statuses** - By default, only `408`, `429`, `500`, `502`, `503`, and `504` status codes trigger retry logic. This can be customized using the `retryableStatuses` option
-- **Non-retryable statuses** - Client errors (4xx except 408 and 429) and other status codes are returned immediately without retrying
-- **Backoff strategy**:
-  - The strategy determines how long to wait between retry attempts
-  - Strategy controls when to stop retrying by returning `NaN`
-  - Use `upto()` wrapper to limit the number of retry attempts
-  - Common strategies include `linear()`, `exponential()`, and `fullJitter()`
-- **Request body cleanup**:
-  - Automatically cancels the response body stream before retrying to prevent memory leaks
-  - This is a best-effort operation that won't block retries if cancellation fails
-- **Error handling**:
-  - Exceeding INT32_MAX (2,147,483,647 milliseconds or ~24.8 days) for delay throws a `RangeError`
-  - When the strategy returns `NaN`, retrying stops and the last response is returned (no error thrown)
-- **Cancellation support**:
-  - Respects `AbortSignal` passed via request options or `Request` object
-  - Cancellation during retry wait period immediately aborts and throws the abort reason
-  - Cancellation during retry request execution propagates the abort signal to the fetch call
-
-## Usage
+## Quick Start
 
 ```typescript
 import { withRetryStatus } from '@qfetch/middleware-retry-status';
-import { fullJitter, upto } from '@proventuslabs/retry-strategies';
+import { withBaseUrl } from '@qfetch/middleware-base-url';
+import { withResponseError } from '@qfetch/middleware-response-error';
+import { exponential, upto } from '@proventuslabs/retry-strategies';
+import { compose } from '@qfetch/core';
 
-const qfetch = withRetryStatus({
-  strategy: () => upto(3, fullJitter(100, 10_000))
-})(fetch);
+// Resilient API client with exponential backoff
+const api = compose(
+  withResponseError(),
+  withRetryStatus({
+    // Retry up to 3 times with exponential backoff (1s, 2s, 4s)
+    strategy: () => upto(3, exponential(1_000, 2)),
+  }),
+  withBaseUrl('https://api.example.com/v1/'),
+)(fetch);
 
-await qfetch('https://api.example.com/data');
+// Automatic retry on transient failures (500, 502, 503, 504, etc.)
+const data = await api('resource').then(r => r.json());
 ```
 
-## Notes
+## Documentation
 
-- Does **not** parse `Retry-After` headers—use `@qfetch/middleware-retry-after` for server-directed timing
-- Retries on `408`, `429`, `500`, `502`, `503`, `504` by default (customizable via `retryableStatuses`)
-- Use `linear()`, `exponential()`, or `fullJitter()` strategies for different backoff patterns
-- Use `upto()` wrapper to limit retry attempts
-- Response bodies are automatically cancelled before retrying to prevent memory leaks
+For complete API reference, examples, and type definitions, see the [API documentation](https://qfetch.github.io/qfetch/modules/_qfetch_middleware_retry_status.html).
 
 ## Standards References
 

--- a/packages/middleware-retry-status/src/with-retry-status.ts
+++ b/packages/middleware-retry-status/src/with-retry-status.ts
@@ -1,5 +1,5 @@
 import { type BackoffStrategy, waitFor } from "@proventuslabs/retry-strategies";
-import type { Middleware } from "@qfetch/core";
+import type { MiddlewareExecutor } from "@qfetch/core";
 
 /**
  * Configuration options for the {@link withRetryStatus} middleware.
@@ -67,9 +67,7 @@ export type RetryStatusOptions = {
  *
  * @see {@link https://www.rfc-editor.org/rfc/rfc9110.html#name-status-codes RFC 9110 - Status Codes}
  */
-export const withRetryStatus: Middleware<[opts: RetryStatusOptions]> = (
-	opts,
-) => {
+export function withRetryStatus(opts: RetryStatusOptions): MiddlewareExecutor {
 	// Get the set of retryable status codes, defaulting to the standard set
 	const retryableStatuses =
 		opts.retryableStatuses ?? DEFAULT_RETRYABLE_STATUSES;
@@ -109,7 +107,7 @@ export const withRetryStatus: Middleware<[opts: RetryStatusOptions]> = (
 
 		return response;
 	};
-};
+}
 
 /**
  * The reason passed to body cancellation.

--- a/turbo/templates/middleware/README.md.hbs
+++ b/turbo/templates/middleware/README.md.hbs
@@ -1,11 +1,12 @@
 # @qfetch/middleware-{{kebabCase middlewareName}}
 
+[TODO: One-liner description]
+
 ## Overview
 
-[TODO: Add a clear, concise description of what this middleware does and its primary purpose.
-Include references to relevant web standards (RFC, MDN, etc.) if applicable.]
+[TODO: 2-3 sentences covering what it does, key behavior, and standards compliance]
 
-Intended for use with the composable middleware system provided by [`@qfetch/core`](https://github.com/qfetch/qfetch/tree/main/packages/core#readme).
+Intended for use with [`@qfetch/core`](https://github.com/qfetch/qfetch/tree/main/packages/core#readme).
 
 ## Installation
 
@@ -13,58 +14,30 @@ Intended for use with the composable middleware system provided by [`@qfetch/cor
 npm install @qfetch/middleware-{{kebabCase middlewareName}}
 ```
 
-## Usage
-
-```typescript
-import { with{{pascalCase middlewareName}} } from '@qfetch/middleware-{{kebabCase middlewareName}}';
-
-const qfetch = with{{pascalCase middlewareName}}({
-  // TODO: Add configuration options
-})(fetch);
-
-await qfetch('https://api.example.com/data');
-```
-
-### Composition with Other Middlewares
+## Quick Start
 
 ```typescript
 import { with{{pascalCase middlewareName}} } from '@qfetch/middleware-{{kebabCase middlewareName}}';
 import { compose } from '@qfetch/core';
 
+// [TODO: Real-world example showing practical usage]
 const qfetch = compose(
-  with{{pascalCase middlewareName}}({ /* options */ }),
+  with{{pascalCase middlewareName}}({
+    // options
+  }),
   // other middlewares...
 )(fetch);
 
-await qfetch('https://api.example.com/data');
+await qfetch('https://api.example.com/resource');
 ```
 
-## API
+## Documentation
 
-### `with{{pascalCase middlewareName}}(opts)`
-
-[TODO: Brief description of the middleware function]
-
-#### Parameters
-
-- `opts` - Configuration object with the following properties:
-  - [TODO: Document each option with type, description, and default value]
-
-#### Returns
-
-A middleware function compatible with `@qfetch/core`.
-
-## Behavior
-
-[TODO: Document key behaviors, edge cases, and how the middleware handles various scenarios]
-
-## Limitations
-
-[TODO: Document known limitations, browser compatibility issues, or constraints]
+For complete API reference, examples, and type definitions, see the [API documentation](https://qfetch.github.io/qfetch/modules/_qfetch_middleware_{{kebabCase middlewareName}}.html).
 
 ## Standards References
 
-[TODO: If applicable, add links to relevant standards]
+[TODO: Add relevant standards]
 
-- [Example: RFC XXXX - Standard Name](https://example.com)
-- [Example: MDN - API Name](https://developer.mozilla.org)
+- [RFC XXXX - Standard Name](https://example.com)
+- [MDN - API Name](https://developer.mozilla.org)

--- a/turbo/templates/middleware/src/with-{{kebabCase middlewareName}}.ts.hbs
+++ b/turbo/templates/middleware/src/with-{{kebabCase middlewareName}}.ts.hbs
@@ -14,15 +14,10 @@
  * HYBRID approach (positional + optional object):
  * - `withQueryParam(name, value, opts?)` - required values + optional config
  *
- * Examples:
- * - Positional: `Middleware<[baseUrl: string | URL]>`
- * - Object: `Middleware<[opts: RetryOptions]>`
- * - Hybrid: `Middleware<[name: string, value: string, opts?: Options]>`
- *
  * Delete this comment block after reading.
  */
 
-import type { Middleware } from "@qfetch/core";
+import type { MiddlewareExecutor } from "@qfetch/core";
 
 /**
  * Configuration options for the {@link with{{pascalCase middlewareName}} } middleware.
@@ -62,9 +57,9 @@ export type {{pascalCase middlewareName}}Options = {
  * await qfetch("https://example.com");
  * ```
  */
-export const with{{pascalCase middlewareName}}: Middleware<[opts: {{pascalCase middlewareName}}Options]> = (
-	opts,
-) => {
+export function with{{pascalCase middlewareName}}(
+	opts: {{pascalCase middlewareName}}Options,
+): MiddlewareExecutor {
 	// TODO: Extract and validate options
 	// const {} = opts;
 
@@ -82,7 +77,7 @@ export const with{{pascalCase middlewareName}}: Middleware<[opts: {{pascalCase m
 
 		return response;
 	};
-};
+}
 
 // TODO: Add helper functions below if needed
 // /**

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,5 +1,16 @@
 {
 	"$schema": "https://typedoc.org/schema.json",
+	"externalSymbolLinkMappings": {
+		"typescript": {
+			"Response": "https://developer.mozilla.org/en-US/docs/Web/API/Response",
+			"Request": "https://developer.mozilla.org/en-US/docs/Web/API/Request",
+			"Headers": "https://developer.mozilla.org/en-US/docs/Web/API/Headers",
+			"URL": "https://developer.mozilla.org/en-US/docs/Web/API/URL",
+			"URLSearchParams": "https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams",
+			"AbortSignal": "https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal",
+			"ReadableStream": "https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream"
+		}
+	},
 	"entryPointStrategy": "packages",
 	"entryPoints": [
 		"packages/core",


### PR DESCRIPTION
## Summary

- Slim down READMEs to essentials, linking to TypeDoc for full API reference
- Refactor core types and middleware exports for better TypeDoc rendering
- Change `TokenProvider` to interface for `implements` support

## README Changes

Reduced README content by ~70% (668 lines removed, 187 added). READMEs now focus on:
- Overview (2-3 sentences)
- Installation
- Quick Start (real-world example with composition)
- Documentation link to TypeDoc
- Standards References (RFC/MDN links)

| Package | Before | After |
|---------|--------|-------|
| middleware-headers | 138 lines | 49 lines |
| middleware-base-url | 90 lines | 45 lines |
| middleware-authorization | 94 lines | 57 lines |
| middleware-query-params | 135 lines | 50 lines |
| middleware-retry-after | 113 lines | 50 lines |
| middleware-retry-status | 98 lines | 48 lines |
| middleware-response-error | 162 lines | 68 lines |

## Core Type Refactoring

- Renamed `FetchFunction` → `FetchFn`
- Renamed `FetchExecutor` → `MiddlewareExecutor`
- Removed `Middleware<T>` type (no longer needed)
- Changed `compose` and `pipeline` from const to function declarations

## Middleware Export Changes

Changed all middleware exports from const arrow functions to function declarations:
- Renders as "Function" instead of "Variable" in TypeDoc
- Shows proper function signature instead of type alias
- Improved IntelliSense and documentation experience

## Other Changes

- Changed `TokenProvider` from type to interface (allows `implements TokenProvider`)
- Added `externalSymbolLinkMappings` to typedoc.json for Web API types (Response, Request, Headers, etc.)
- Updated turbo template for new middleware packages

## Test plan

- [x] All tests pass
- [x] Type checking passes
- [x] Biome linting passes
- [ ] Verify TypeDoc renders correctly at https://qfetch.github.io/qfetch/
- [ ] Review quick start examples for real-world relevance