### PR TITLE
ci: add publish dry-run verification

### DIFF
--- a/.github/workflows/_template.package-cd.yaml
+++ b/.github/workflows/_template.package-cd.yaml
@@ -17,9 +17,83 @@ on:
         type: string
 
 jobs:
+  verify-jsr:
+    timeout-minutes: 2
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Cache Turbo
+        uses: actions/cache@v4
+        with:
+          path: |
+            .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: "package.json"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --filter=${{ inputs.package_name }}...
+
+      - name: Verify JSR publish
+        run: pnpx jsr publish --dry-run
+        working-directory: ${{ inputs.package_path }}
+
+  verify-npm:
+    timeout-minutes: 2
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Cache Turbo
+        uses: actions/cache@v4
+        with:
+          path: |
+            .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: "package.json"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --filter=${{ inputs.package_name }}...
+
+      - name: Build package
+        run: pnpm build --filter=${{ inputs.package_name }}
+
+      - name: Verify npm publish
+        run: npm publish --dry-run
+        working-directory: ${{ inputs.package_path }}
+
   build-and-upload:
     timeout-minutes: 2
     runs-on: ubuntu-24.04
+    needs: [verify-jsr, verify-npm]
 
     steps:
       - name: Checkout code
@@ -117,6 +191,15 @@ jobs:
 
       - name: Enable Corepack
         run: corepack enable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: "package.json"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --filter=${{ inputs.package_name }}...
 
       - name: Publish to jsr registry
         run: pnpx jsr publish

--- a/.github/workflows/release-verify.yaml
+++ b/.github/workflows/release-verify.yaml
@@ -1,0 +1,101 @@
+name: Release Verify
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  detect-release-please:
+    if: startsWith(github.head_ref, 'release-please--')
+    runs-on: ubuntu-24.04
+    outputs:
+      package_path: ${{ steps.extract.outputs.package_path }}
+      package_name: ${{ steps.extract.outputs.package_name }}
+
+    steps:
+      - name: Extract package info from branch
+        id: extract
+        run: |
+          # Branch format: release-please--branches--main--components--packages-<package-name>
+          BRANCH="${{ github.head_ref }}"
+
+          # Extract package directory name (e.g., "middleware-retry-after" from "packages-middleware-retry-after")
+          PACKAGE_DIR=$(echo "$BRANCH" | sed 's/.*--packages-//')
+
+          echo "package_path=packages/$PACKAGE_DIR" >> "$GITHUB_OUTPUT"
+          echo "package_name=@qfetch/$PACKAGE_DIR" >> "$GITHUB_OUTPUT"
+
+  verify-jsr:
+    needs: detect-release-please
+    timeout-minutes: 2
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Cache Turbo
+        uses: actions/cache@v4
+        with:
+          path: |
+            .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: "package.json"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --filter=${{ needs.detect-release-please.outputs.package_name }}...
+
+      - name: Verify JSR publish
+        run: pnpx jsr publish --dry-run
+        working-directory: ${{ needs.detect-release-please.outputs.package_path }}
+
+  verify-npm:
+    needs: detect-release-please
+    timeout-minutes: 2
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Cache Turbo
+        uses: actions/cache@v4
+        with:
+          path: |
+            .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: "package.json"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --filter=${{ needs.detect-release-please.outputs.package_name }}...
+
+      - name: Build package
+        run: pnpm build --filter=${{ needs.detect-release-please.outputs.package_name }}
+
+      - name: Verify npm publish
+        run: npm publish --dry-run
+        working-directory: ${{ needs.detect-release-please.outputs.package_path }}

--- a/packages/middlewares/jsr.json
+++ b/packages/middlewares/jsr.json
@@ -4,6 +4,15 @@
 	"version": "0.1.0",
 	"license": "MIT",
 	"exports": "./src/index.ts",
+	"imports": {
+		"@qfetch/middleware-authorization": "jsr:@qfetch/middleware-authorization@0.1",
+		"@qfetch/middleware-base-url": "jsr:@qfetch/middleware-base-url@0.1",
+		"@qfetch/middleware-headers": "jsr:@qfetch/middleware-headers@0.1",
+		"@qfetch/middleware-query-params": "jsr:@qfetch/middleware-query-params@0.1",
+		"@qfetch/middleware-response-error": "jsr:@qfetch/middleware-response-error@0.1",
+		"@qfetch/middleware-retry-after": "jsr:@qfetch/middleware-retry-after@0.1",
+		"@qfetch/middleware-retry-status": "jsr:@qfetch/middleware-retry-status@0.1"
+	},
 	"publish": {
 		"include": ["src/**/*.ts", "README.md", "LICENSE", "jsr.json"]
 	}

--- a/packages/qfetch/jsr.json
+++ b/packages/qfetch/jsr.json
@@ -3,6 +3,16 @@
 	"name": "@qfetch/qfetch",
 	"version": "0.1.0",
 	"exports": "./src/index.ts",
+	"imports": {
+		"@qfetch/core": "jsr:@qfetch/core@0.2",
+		"@qfetch/middleware-authorization": "jsr:@qfetch/middleware-authorization@0.1",
+		"@qfetch/middleware-base-url": "jsr:@qfetch/middleware-base-url@0.1",
+		"@qfetch/middleware-headers": "jsr:@qfetch/middleware-headers@0.1",
+		"@qfetch/middleware-query-params": "jsr:@qfetch/middleware-query-params@0.1",
+		"@qfetch/middleware-response-error": "jsr:@qfetch/middleware-response-error@0.1",
+		"@qfetch/middleware-retry-after": "jsr:@qfetch/middleware-retry-after@0.1",
+		"@qfetch/middleware-retry-status": "jsr:@qfetch/middleware-retry-status@0.1"
+	},
 	"publish": {
 		"include": ["src/**/*.ts", "README.md", "LICENSE", "jsr.json"]
 	}


### PR DESCRIPTION
## Summary

Adds parallel dry-run verification for both npm and JSR publishing to prevent partial publishes.

## CD Flow

```
verify-jsr ─┬─> build-and-upload ─┬─> publish-npm
verify-npm ─┘                     └─> publish-jsr
```

Both verify jobs must pass before any artifacts are uploaded or published.

## Changes

**CD Template (`_template.package-cd.yaml`):**
- Add `verify-jsr` job: runs `jsr publish --dry-run`
- Add `verify-npm` job: runs `npm publish --dry-run`
- Both verify jobs run in parallel
- `build-and-upload` depends on both verify jobs passing
- `publish-npm` and `publish-jsr` run after build-and-upload

**JSR config:**
- Add imports map to `middlewares` and `qfetch` aggregate packages

## Test plan

- [ ] Verify jobs run in parallel
- [ ] Build-and-upload only runs if both verify jobs pass
- [ ] Publish jobs only run after successful build