### PR TITLE
ci: trigger documentation build via workflow_call after releases

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,9 +1,7 @@
 name: Documentation
 
 on:
-  release:
-    types:
-      - published
+  workflow_call:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/packages.cd.yaml
+++ b/.github/workflows/packages.cd.yaml
@@ -142,3 +142,20 @@ jobs:
       package_path: "packages/middlewares"
       package_name: "@qfetch/middlewares"
       package_tag: ${{ needs.release-please.outputs['packages/middlewares--tag_name'] }}
+
+  documentation:
+    needs: release-please
+    if: >-
+      ${{
+        needs.release-please.outputs['packages/core--release_created'] == 'true' ||
+        needs.release-please.outputs['packages/middleware-retry-after--release_created'] == 'true' ||
+        needs.release-please.outputs['packages/middleware-retry-status--release_created'] == 'true' ||
+        needs.release-please.outputs['packages/middleware-base-url--release_created'] == 'true' ||
+        needs.release-please.outputs['packages/middleware-authorization--release_created'] == 'true' ||
+        needs.release-please.outputs['packages/middleware-query-params--release_created'] == 'true' ||
+        needs.release-please.outputs['packages/middleware-headers--release_created'] == 'true' ||
+        needs.release-please.outputs['packages/middleware-response-error--release_created'] == 'true' ||
+        needs.release-please.outputs['packages/qfetch--release_created'] == 'true' ||
+        needs.release-please.outputs['packages/middlewares--release_created'] == 'true'
+      }}
+    uses: ./.github/workflows/docs.yaml


### PR DESCRIPTION
## Summary
- Add `workflow_call` trigger to `docs.yaml` to allow it to be called from other workflows
- Add `documentation` job in `packages.cd.yaml` that triggers after any package release is created

This fixes the issue where documentation wasn't auto-updating after release-please PRs were merged (due to GitHub's limitation that GITHUB_TOKEN actions can't trigger other workflows).

## Test plan
- [ ] Merge a release-please PR and verify documentation workflow runs automatically